### PR TITLE
Support no_std operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `#![no_std]` is now supported out of the box. (You don’t need to opt into any features, it just works.)
 
 ## 0.3.0 - 2019-02-19
 ### Added

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,0 +1,68 @@
+#![no_std]
+
+extern crate typed_builder;
+
+use typed_builder::TypedBuilder;
+
+#[test]
+fn test_simple() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        x: i32,
+        y: i32,
+    }
+
+    assert!(Foo::builder().x(1).y(2).build() == Foo { x: 1, y: 2 });
+    assert!(Foo::builder().y(1).x(2).build() == Foo { x: 2, y: 1 });
+}
+
+#[test]
+fn test_lifetime() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<'a, 'b> {
+        x: &'a i32,
+        y: &'b i32,
+    }
+
+    assert!(Foo::builder().x(&1).y(&2).build() == Foo { x: &1, y: &2 });
+}
+
+#[test]
+fn test_generics() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<S, T: Default> {
+        x: S,
+        y: T,
+    }
+
+    assert!(Foo::builder().x(1).y(2).build() == Foo { x: 1, y: 2 });
+}
+
+#[test]
+fn test_into() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        x: i32,
+    }
+
+    assert!(Foo::builder().x(1u8).build() == Foo { x: 1 });
+}
+
+#[test]
+fn test_default() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        #[builder(default)]
+        x: Option<i32>,
+        #[builder(default=10)]
+        y: i32,
+        #[builder(default_code="[20, 30, 40]")]
+        z: [i32; 3]
+    }
+
+    assert!(Foo::builder().build() == Foo { x: None, y: 10, z: [20, 30, 40] });
+    assert!(Foo::builder().x(1).build() == Foo { x: Some(1), y: 10, z: [20, 30, 40] });
+    assert!(Foo::builder().y(2).build() == Foo { x: None, y: 2, z: [20, 30, 40] });
+    assert!(Foo::builder().x(1).y(2).build() == Foo { x: Some(1), y: 2, z: [20, 30, 40] });
+    assert!(Foo::builder().z([1, 2, 3]).build() == Foo { x: None, y: 10, z: [1, 2, 3] });
+}


### PR DESCRIPTION
Fixes #9.

The added no_std tests are just a straight copy of the other tests, with `Vec<i32>` changed to `[i32; 3]`.