### PR TITLE
insert type tuples before generic types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- [**BREAKING**] now state types are placed before original generic types. 
+  Previously, all state types are appended to generic arguments. For example, 
+  `Foo<'a, X, Y>` yields `FooBuilder<'a, X, Y, ((), ())>` **previously**, and 
+  now it becomes `FooBuilder<'a, ((), ()), X, Y, >.`. This change fix compiler error 
+  for struct with default type like `Foo<'a, X, Y=Bar>`. Rust only allow type 
+  parameters with a default to be trailing.
 
 ## 0.4.0 - 2019-12-13
 ### Added

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -249,9 +249,9 @@ impl<'a> StructInfo<'a> {
         });
         let mut target_generics = ty_generics.clone();
 
-        let index_before_type_in_generics = target_generics.iter().fold(0, |ix, arg| {
-            if let syn::GenericArgument::Type(_) = arg { ix } else { ix + 1 }
-        });
+        let index_before_type_in_generics = target_generics.iter().take_while(|&&arg| {
+            if let syn::GenericArgument::Type(_) = arg { false } else { true }
+        }).count();
         target_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(target_generics_tuple.into()));
         ty_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(ty_generics_tuple.into()));
         let (impl_generics, _, where_clause) = generics.split_for_impl();

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -249,11 +249,11 @@ impl<'a> StructInfo<'a> {
         });
         let mut target_generics = ty_generics.clone();
 
-        let ix = target_generics.iter().fold(0, |ix, arg| {
+        let index_before_type_in_generics = target_generics.iter().fold(0, |ix, arg| {
             if let syn::GenericArgument::Type(_) = arg { ix } else { ix + 1 }
         });
-        target_generics.insert(ix, syn::GenericArgument::Type(target_generics_tuple.into()));
-        ty_generics.insert(ix, syn::GenericArgument::Type(ty_generics_tuple.into()));
+        target_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(target_generics_tuple.into()));
+        ty_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(ty_generics_tuple.into()));
         let (impl_generics, _, where_clause) = generics.split_for_impl();
         let doc = match field.builder_attr.doc {
             Some(ref doc) => quote!(#[doc = #doc]),

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -249,11 +249,11 @@ impl<'a> StructInfo<'a> {
         });
         let mut target_generics = ty_generics.clone();
 
-        let index_before_type_in_generics = target_generics.iter().take_while(|&&arg| {
-            if let syn::GenericArgument::Type(_) = arg { false } else { true }
+        let index_after_lifetime_in_generics = target_generics.iter().filter(|arg| {
+            if let syn::GenericArgument::Lifetime(_) = arg { true } else { false }
         }).count();
-        target_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(target_generics_tuple.into()));
-        ty_generics.insert(index_before_type_in_generics, syn::GenericArgument::Type(ty_generics_tuple.into()));
+        target_generics.insert(index_after_lifetime_in_generics, syn::GenericArgument::Type(target_generics_tuple.into()));
+        ty_generics.insert(index_after_lifetime_in_generics, syn::GenericArgument::Type(ty_generics_tuple.into()));
         let (impl_generics, _, where_clause) = generics.split_for_impl();
         let doc = match field.builder_attr.doc {
             Some(ref doc) => quote!(#[doc = #doc]),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -277,33 +277,13 @@ fn test_builder_type_with_default_on_generic_type() {
     assert!(Types::builder().x(()).y(()).build() == Types { x:(), y: () });
 
     #[derive(PartialEq, TypedBuilder)]
-    struct Constrain<X:Default, Y:Default=usize> {
+    struct TypeAndLifetime<'a, X,Y:Default, Z=usize> {
         x: X,
         y: Y,
+        z:&'a Z,
     }
-    assert!(Constrain::builder().x(1).y(4).build() == Constrain { x:1, y: 4 });
-
-    #[derive(PartialEq, TypedBuilder)]
-    struct TypeAndConstrain<X:Default, Y=()> {
-        x: X,
-        y: Y,
-    }
-    assert!(TypeAndConstrain::builder().x(1).y(()).build() == TypeAndConstrain { x:1, y: () });
-
-    #[derive(PartialEq, TypedBuilder)]
-    struct TypeAndConstrain2<X,Y:Default, C=()> {
-        x: X,
-        y: Y,
-        c:C,
-    }
-    assert!(TypeAndConstrain2::builder().x(()).y(0).c(()).build() == TypeAndConstrain2 { x:(), y: 0, c:() });
-
-    #[derive(PartialEq, TypedBuilder)]
-    struct TypeAndConstrain3<X, Y:Default=()> {
-        x: X,
-        y: Y,
-    }
-    assert!(TypeAndConstrain3::builder().x(()).y(0).build() == TypeAndConstrain3 { x:(), y: 0 });
+    let a = 0;
+    assert!(TypeAndLifetime::builder().x(()).y(0).z(&a).build() == TypeAndLifetime { x:(), y: 0, z:&0 });
 
     #[derive(PartialEq, TypedBuilder)]
     struct Foo<'a, X, Y: Default, Z:Default=usize, M =()> {
@@ -324,8 +304,6 @@ fn test_builder_type_with_default_on_generic_type() {
             self.m(())
         }
     }
-
-    let a = 0;
 
     // compile test if rustc can infer type for `z` and `m`
     Foo::<(), _, _, f64>::builder().x(()).y(&a).z_default().m(1.0).build();

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -328,8 +328,8 @@ fn test_builder_type_with_default_on_generic_type() {
     let a = 0;
 
     // compile test if rustc can infer type for `z` and `m`
-    let foo = Foo::<(), _, _, f64>::builder().x(()).y(&a).z_default().m(1.0).build();
-    let foo = Foo::<(), _, _, _>::builder().x(()).y(&a).z_default().m_default().build();
+    Foo::<(), _, _, f64>::builder().x(()).y(&a).z_default().m(1.0).build();
+    Foo::<(), _, _, _>::builder().x(()).y(&a).z_default().m_default().build();
 
     assert!(Foo::builder().x(()).y(&a).z_default().m(1.0).build() == Foo { x:(), y: &0, z: 0, m:1.0 });
     assert!(Foo::builder().x(()).y(&a).z(9).m(1.0).build() == Foo { x:(), y: &0, z: 9, m:1.0 });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -328,8 +328,8 @@ fn test_builder_type_with_default_on_generic_type() {
     let a = 0;
 
     // compile test if rustc can infer type for `z` and `m`
-    let foo = Foo::<(), _, _, f64>::builder().x(()).y(&x).z_default().m(1.0).build();
-    let foo = Foo::<(), _, _, _>::builder().x(()).y(&x).z_default().m_default().build();
+    let foo = Foo::<(), _, _, f64>::builder().x(()).y(&a).z_default().m(1.0).build();
+    let foo = Foo::<(), _, _, _>::builder().x(()).y(&a).z_default().m_default().build();
 
     assert!(Foo::builder().x(()).y(&a).z_default().m(1.0).build() == Foo { x:(), y: &0, z: 0, m:1.0 });
     assert!(Foo::builder().x(()).y(&a).z(9).m(1.0).build() == Foo { x:(), y: &0, z: 9, m:1.0 });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -257,8 +257,8 @@ fn test_builder_type_stability_with_other_generics() {
         y: Y,
     }
 
-    impl<X: Default, Y, Y_> FooBuilder<X, Y, ((), Y_)> {
-        fn x_default(self) -> FooBuilder<X, Y, ((X,), Y_)> {
+    impl<X: Default, Y, Y_> FooBuilder<((), Y_), X, Y> {
+        fn x_default(self) -> FooBuilder<((X,), Y_), X, Y> {
             self.x(X::default())
         }
     }


### PR DESCRIPTION
Currently, the macro push type tuples to the end of generics.

Say we have a `Foo<X, Y>` struct, the signature of  generated `FooBuilder` is ` FooBuilder<X, Y, ((), ())>`.

When the original struct has a type parameter with a default like `Foo<X, Y=Bar>`, this will yield a builder of  ` FooBuilder<X, Y=Bar, ((), ())>`. 

Unfortunately, rust compiler complains that

> type parameters with a default must be trailing

In other words, rust only allow a type parameter with a default to be trailing, like  ` FooBuilder<X, ((), ()), Y=Bar>`.

## Solution

My solution is straight forward: instead of appending all state machine types, insert empty tuples type right before any generic types.

For instance, suppose we have a generic type:
 ```rust
Foo<'a, 'b, X, Y=Bar>{x:&'a X, y:&'b Y}
```
Insert marker generic types right before all generic types:
```rust
impl<'a, 'b, X, Y, _x,_y> FooBuilder<'a, 'b, (_x, _y), X, Y=Bar>
```

In this way, type parameters with a default are forced to be at the end of generic arguments.

All tests are passed.