### PR TITLE
Generic type parameter inference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- `#[builder(no_into)]` attribute on fields, to skip a `Into` conversion from 
+- `#[builder(skip_into)]` attribute on fields, to skip a `Into` conversion from 
   input variable to target type, and thus enable rustc inference for generic type.
 
 ## 0.4.1 - 2020-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- `#[builder(no_into)]` attribute on fields, to skip a `Into` conversion from 
+  input variable to target type, and thus enable rustc inference for generic type.
 
 ## 0.4.1 - 2020-01-17
 ### Fixed

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -58,7 +58,7 @@ impl<'a> FieldInfo<'a> {
 pub struct FieldBuilderAttr {
     pub doc: Option<syn::Expr>,
     pub skip: bool,
-    pub no_into: bool,
+    pub skip_into: bool,
     pub default: Option<syn::Expr>,
 }
 
@@ -150,8 +150,8 @@ impl FieldBuilderAttr {
                         self.skip = true;
                         Ok(())
                     }
-                    "no_into" => {
-                        self.no_into = true;
+                    "skip_into" => {
+                        self.skip_into = true;
                         Ok(())
                     }
                     "default" => {

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -58,6 +58,7 @@ impl<'a> FieldInfo<'a> {
 pub struct FieldBuilderAttr {
     pub doc: Option<syn::Expr>,
     pub skip: bool,
+    pub no_into: bool,
     pub default: Option<syn::Expr>,
 }
 
@@ -147,6 +148,10 @@ impl FieldBuilderAttr {
                 match name.as_str() {
                     "skip" => {
                         self.skip = true;
+                        Ok(())
+                    }
+                    "no_into" => {
+                        self.no_into = true;
                         Ok(())
                     }
                     "default" => {

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -259,7 +259,7 @@ impl<'a> StructInfo<'a> {
             Some(ref doc) => quote!(#[doc = #doc]),
             None => quote!(),
         };
-        let (generic_arg, field_ident) = if field.builder_attr.no_into{
+        let (generic_arg, field_ident) = if field.builder_attr.skip_into{
             (quote!(), quote!(#field_type))
         }
         else{

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -259,11 +259,18 @@ impl<'a> StructInfo<'a> {
             Some(ref doc) => quote!(#[doc = #doc]),
             None => quote!(),
         };
+        let (generic_arg, field_ident) = if field.builder_attr.no_into{
+            (quote!(), quote!(#field_type))
+        }
+        else{
+            (quote!(<#generic_ident: #core::convert::Into<#field_type>>), quote!(#generic_ident))
+        };
+
         Ok(quote! {
             #[allow(dead_code, non_camel_case_types, missing_docs)]
             impl #impl_generics #builder_name < #( #ty_generics ),* > #where_clause {
                 #doc
-                pub fn #field_name<#generic_ident: #core::convert::Into<#field_type>>(self, #field_name: #generic_ident) -> #builder_name < #( #target_generics ),* > {
+                pub fn #field_name #generic_arg (self, #field_name: #field_ident) -> #builder_name < #( #target_generics ),* > {
                     let #field_name = (#field_name.into(),);
                     let ( #(#descructuring,)* ) = self.fields;
                     #builder_name {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -312,3 +312,18 @@ fn test_builder_type_with_default_on_generic_type() {
     assert!(Foo::builder().x(()).y(&a).z_default().m(1.0).build() == Foo { x:(), y: &0, z: 0, m:1.0 });
     assert!(Foo::builder().x(()).y(&a).z(9).m(1.0).build() == Foo { x:(), y: &0, z: 9, m:1.0 });
 }
+
+#[test]
+fn test_builder_type_no_into() {
+
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<X> {
+        #[builder(no_into)]
+        x: X,
+    }
+
+    // compile test if rustc can infer type for `x`
+    Foo::builder().x(()).build();
+
+    assert!(Foo::builder().x(()).build() == Foo { x:()});
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -314,11 +314,11 @@ fn test_builder_type_with_default_on_generic_type() {
 }
 
 #[test]
-fn test_builder_type_no_into() {
+fn test_builder_type_skip_into() {
 
     #[derive(PartialEq, TypedBuilder)]
     struct Foo<X> {
-        #[builder(no_into)]
+        #[builder(skip_into)]
         x: X,
     }
 


### PR DESCRIPTION
## Description
Currently, all setters use `Into` trait to gain a flexible and ergonomic API. 

For example, for `Foo{s:String}`, a setter with a signature of `fn s<T: Into<String>>(input:s)` can now accept both `&str` and `String`. 

However, `Into` conversion design confuses rustc when there is any generic type. When the setter get a concrete type, there is no way that rustc can infer what type to convert into. So we have to explicitly describe the generic type, for instance, `Foo::<uszie>::builder().x(0).build()` for `Foo<T>{x:T}`. 

This is really annoying when the number of generic types increases.

## Possible Solution

Maybe we should offer a method to disable `Into` conversion.

A good way is to implement a field attribute, say `skip_into`, so user can disable conversion on demand.

```rust
    #[derive(TypedBuilder)]
    struct Foo<X> {
        #[builder(skip_into)]
        x: X,
    }
```

By default, `Into` conversion is still enabled for all field setters, so there is no need to modify previous code.

Well, I think there must be a better name for `skip_into`, but it just eludes my mind.