### PR TITLE
Specific errors for missing or repeated fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,12 +141,18 @@ fn impl_my_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Error> {
                     .included_fields()
                     .map(|f| struct_info.field_impl(f).unwrap());
                 let fields = quote!(#(#fields)*).into_iter();
+                let required_fields = struct_info
+                    .included_fields()
+                    .filter(|f| f.builder_attr.default.is_none())
+                    .map(|f| struct_info.required_field_impl(f).unwrap());
+                let required_fields = quote!(#(#required_fields)*).into_iter();
                 let build_method = struct_info.build_method_impl();
 
                 quote! {
                     #builder_creation
                     #conversion_helper
                     #( #fields )*
+                    #( #required_fields )*
                     #build_method
                 }
             }


### PR DESCRIPTION
# Description

As described in the README, errors when a field has not been set when `build` is called or when the setter is called twice are just `no method` errors.

# Implementation

The suggested implementation is based on the proposed idea from #3. 

It does not provide very clean errors, but still more specific than the (confusing) `no method`.

Errors for missing fields when the `build` method is called only report the first missing field. This allows to keep a number of `impl` equal to the number of fields and avoid an exponential number.

## Setting a field twice

For each field, there is an `impl` containing setter for the field, for builders who already have that field set.

That setter takes as argument an empty enum to cause a compilation error, instead of the field.
This enum has a particular name to explain a bit the error.
The setter is also marked as deprecated for an error message a bit cleaner.

The error for the example from the README gives:

```
warning: use of deprecated item 'FooBuilder::<(__x, (std::option::Option<i32>,), __z, __w)>::y': Repeated field y
  --> src/main.rs:42:30
   |
42 |     Foo::builder().x(1).y(2).y(3); // y is specified twice
   |                              ^
   |
   = note: `#[warn(deprecated)]` on by default

error[E0308]: mismatched types
  --> src/main.rs:42:32
   |
42 |     Foo::builder().x(1).y(2).y(3); // y is specified twice
   |                                ^ expected enum `FooBuilder_Error_Repeated_field_y`, found integer
   |
   = note: expected type `FooBuilder_Error_Repeated_field_y`
              found type `{integer}`
```

## Calling `build` when a field is missing

For each field, there is an `impl` containing a `build` method for builders that have a required field missing but the previous (in the struct declaration order) required fields present.

The method takes an additional argument which is an empty enum to cause a compilation error.
The method is also marked as deprecated for an error message a bit cleaner.

The error for the example from the README gives:

```
warning: use of deprecated item 'FooBuilder::<((), __y, __z, __w)>::build': Missing required field x
  --> src/main.rs:41:20
   |
41 |     Foo::builder().build(); // missing x
   |                    ^^^^^
   |
   = note: `#[warn(deprecated)]` on by default

error[E0061]: this function takes 1 parameter but 0 parameters were supplied
  --> src/main.rs:41:20
   |
6  | #[derive(TypedBuilder)]
   |          ------------ defined here
...
41 |     Foo::builder().build(); // missing x
   |                    ^^^^^ expected 1 parameter
```

---

I am not sure that the `impl` causing errors for setting a field twice is a really good idea. As the method implemented could be used as a getter to mutate an already set parameter. I don't know if anyone is doing this. The interest of the specific error should be compared against that.

