### PR TITLE
Add ability to use both StripOption and AutoInto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Ability to use `into` and `strip_option` simultaneously for a field.
 
 ## 0.5.1 - 2020-01-26
 ### Fixed

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -279,6 +279,14 @@ impl<'a> StructInfo<'a> {
                     quote!(Some(#field_name)),
                 )
             },
+            SetterArgSugar::StripOptionAutoInto => {
+                let internal_type = field.type_from_inside_option()
+                    .ok_or_else(|| Error::new_spanned(&field_type, "can't `strip_option` - field is not `Option<...>`"))?;
+                (
+                    quote!(impl #core::convert::Into<#internal_type>),
+                    quote!(Some(#field_name.into())),
+                )
+            },
         };
 
         let repeated_fields_error_type_name = syn::Ident::new(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -67,6 +67,28 @@ fn test_into() {
 }
 
 #[test]
+fn test_strip_option_with_into() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        #[builder(setter(strip_option, into))]
+        x: Option<i32>,
+    }
+
+    assert!(Foo::builder().x(1u8).build() == Foo { x: Some(1) });
+}
+
+#[test]
+fn test_into_with_strip_option() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        #[builder(setter(into, strip_option))]
+        x: Option<i32>,
+    }
+
+    assert!(Foo::builder().x(1u8).build() == Foo { x: Some(1) });
+}
+
+#[test]
 fn test_default() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo {


### PR DESCRIPTION
I accidentally rustfmt'd the code and I can clean up this PR tomorrow without the formatting changes, but here's a change to support Into for stripped option types.