### PR TITLE
Fix lifetime bounds erroneously preserved in phantom generics

### DIFF
--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -85,7 +85,10 @@ impl<'a> StructInfo<'a> {
         });
         let phantom_generics = self.generics.params.iter().map(|param| {
             let t = match param {
-                syn::GenericParam::Lifetime(lifetime) => quote!(&#lifetime ()),
+                syn::GenericParam::Lifetime(lifetime) => {
+                    let lifetime = &lifetime.lifetime;
+                    quote!(&#lifetime ())
+                }
                 syn::GenericParam::Type(ty) => {
                     let ty = &ty.ident;
                     quote!(#ty)

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -26,6 +26,17 @@ fn test_lifetime() {
 }
 
 #[test]
+fn test_lifetime_bounded() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<'a, 'b: 'a> {
+        x: &'a i32,
+        y: &'b i32,
+    }
+
+    assert!(Foo::builder().x(&1).y(&2).build() == Foo { x: &1, y: &2 });
+}
+
+#[test]
 fn test_mutable_borrows() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo<'a, 'b> {


### PR DESCRIPTION
It was a bit tricky to figure this out (since I'm using this macro nested inside another much larger one), but I think I've gotten better at debugging proc macros with invalid output now 😅

In any case, thanks for making this crate! It's going to save me a huge amount of work.
I've included the test for this issue a commit earlier than the fix, so if you'd like to preserve bisectable history, please squash them when merging.