### PR TITLE
Remove " (they accept `Into` values)" from default builder docs

### DIFF
--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -107,7 +107,7 @@ impl<'a> StructInfo<'a> {
             None => {
                 let doc = format!("
                     Create a builder for building `{name}`.
-                    On the builder, call {setters} to set the values of the fields (they accept `Into` values).
+                    On the builder, call {setters} to set the values of the fields.
                     Finally, call `.build()` to create the instance of `{name}`.
                     ",
                     name=self.name,


### PR DESCRIPTION
I'm about to start work on a pull/feature request, but for now here's a small thing I noticed while using the crate earlier.

The default `.builder()` method docs still mention `Into` regardless of whether that is actually enabled for any of the setters, so I removed the mention entirely.

Alternatively, I could also make it show up only when that setting is enabled on all of them.