### PR TITLE
Fix "type parameters must be declared prior to const parameters"

### DIFF
--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -433,6 +433,11 @@ impl<'a> StructInfo<'a> {
         } = *self;
 
         let generics = self.modify_generics(|g| {
+            let index_after_lifetime_in_generics = g
+                .params
+                .iter()
+                .filter(|arg| matches!(arg, syn::GenericParam::Lifetime(_)))
+                .count();
             for field in self.included_fields() {
                 if field.builder_attr.default.is_some() {
                     let trait_ref = syn::TraitBound {
@@ -452,7 +457,7 @@ impl<'a> StructInfo<'a> {
                     };
                     let mut generic_param: syn::TypeParam = field.generic_ident.clone().into();
                     generic_param.bounds.push(trait_ref.into());
-                    g.params.push(generic_param.into());
+                    g.params.insert(index_after_lifetime_in_generics, generic_param.into());
                 }
             }
         });

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -66,18 +66,6 @@ fn test_generics() {
     assert!(Foo::builder().x(1).y(2).build() == Foo { x: 1, y: 2 });
 }
 
-#[ignore = "min_const_generics is not in stable yet"]
-#[test]
-fn test_const_generics() {
-    #[derive(PartialEq, TypedBuilder)]
-    struct Foo<'a, T, const N: usize> {
-        x: i32,
-        y: [&'a T; N],
-    }
-
-    assert!(Foo::builder().x(1).y([&2]).build() == Foo { x: 1, y: [&2] });
-}
-
 #[test]
 fn test_into() {
     #[derive(PartialEq, TypedBuilder)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -36,17 +36,6 @@ fn test_lifetime_bounded() {
     assert!(Foo::builder().x(&1).y(&2).build() == Foo { x: &1, y: &2 });
 }
 
-#[cfg(nightly)]
-#[test]
-fn test_const_generics() {
-    #[derive(PartialEq, TypedBuilder)]
-    struct Foo<'a, T, const N: usize> {
-        x: [&'a T; N],
-    }
-
-    assert!(Foo::builder().x([&1, &2]).build() == Foo { x: [&1, &2] });
-}
-
 #[test]
 fn test_mutable_borrows() {
     #[derive(PartialEq, TypedBuilder)]
@@ -75,6 +64,18 @@ fn test_generics() {
     }
 
     assert!(Foo::builder().x(1).y(2).build() == Foo { x: 1, y: 2 });
+}
+
+#[ignore = "min_const_generics is not in stable yet"]
+#[test]
+fn test_const_generics() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<'a, T, const N: usize> {
+        x: i32,
+        y: [&'a T; N],
+    }
+
+    assert!(Foo::builder().x(1).y([&2]).build() == Foo { x: 1, y: [&2] });
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -36,6 +36,17 @@ fn test_lifetime_bounded() {
     assert!(Foo::builder().x(&1).y(&2).build() == Foo { x: &1, y: &2 });
 }
 
+#[cfg(nightly)]
+#[test]
+fn test_const_generics() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo<'a, T, const N: usize> {
+        x: [&'a T; N],
+    }
+
+    assert!(Foo::builder().x([&1, &2]).build() == Foo { x: [&1, &2] });
+}
+
 #[test]
 fn test_mutable_borrows() {
     #[derive(PartialEq, TypedBuilder)]


### PR DESCRIPTION
As `min_const_generics` is going to available in Rust 1.51, I find the generated type parameter ordering is not correct when using with const parameters.