### PR TITLE
Avoid consumer-visible clippy::pedantic warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,16 +79,16 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## 0.4.0 - 2019-12-13
 ### Added
-- `#![no_std]` is now supported out of the box. (You don’t need to opt into any
+- `#![no_std]` is now supported out of the box. (You don't need to opt into any
   features, it just works.)
 - [**BREAKING**] a `default_code` expression can now refer to the values of
   earlier fields by name (This is extremely unlikely to break your code, but
   could in theory due to shadowing)
 - `#[builder(skip)]` on fields, to not provide a method to set that field.
 - Control of documentation:
-  - `#[builder(doc = "…")]` on fields, to document the field’s method on the
+  - `#[builder(doc = "…")]` on fields, to document the field's method on the
     builder. Unlike `#[doc]`, you can currently only have one value rather than
-    one attribute per line; but that’s not a big deal since you don’t get to
+    one attribute per line; but that's not a big deal since you don't get to
     use the `///` sugar anyway. Just use a multiline string.
   - `#[builder(doc, builder_method_doc = "…", builder_type_doc = "…",
     build_method_doc = "…")]` on structs:

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -118,7 +118,7 @@ impl FieldBuilderAttr {
                     return Err(Error::new_spanned(attr.tokens.clone(), "Expected (<...>)"));
                 }
             }
-            // Stash its span for later (we don’t yet know if it’ll be an error)
+            // Stash its span for later (we don't yet know if it'll be an error)
             if self.setter.skip && skip_tokens.is_none() {
                 skip_tokens = Some(attr.tokens.clone());
             }

--- a/src/field_info.rs
+++ b/src/field_info.rs
@@ -166,7 +166,7 @@ impl FieldBuilderAttr {
                 let name = path_to_single_string(&path.path).ok_or_else(|| Error::new_spanned(&path, "Expected identifier"))?;
                 match name.as_str() {
                     "default" => {
-                        self.default = Some(syn::parse(quote!(Default::default()).into()).unwrap());
+                        self.default = Some(syn::parse(quote!(::core::default::Default::default()).into()).unwrap());
                         Ok(())
                     }
                     _ => Err(Error::new_spanned(&path, format!("Unknown parameter {:?}", name))),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -69,7 +69,7 @@ mod util;
 ///
 /// - `doc`: enable documentation of the builder type. By default, the builder type is given
 ///   `#[doc(hidden)]`, so that the `builder()` method will show `FooBuilder` as its return type,
-///   but it won’t be a link. If you turn this on, the builder type and its `build` method will get
+///   but it won't be a link. If you turn this on, the builder type and its `build` method will get
 ///   sane defaults. The field methods on the builder will be undocumented by default.
 ///
 /// - `builder_method_doc = "…"` replaces the default documentation that will be generated for the
@@ -119,7 +119,7 @@ mod util;
 ///
 /// - `setter(...)`: settings for the field setters. The following values are permitted inside:
 ///
-///   - `doc = "…"`: sets the documentation for the field’s setter on the builder type. This will be
+///   - `doc = "…"`: sets the documentation for the field's setter on the builder type. This will be
 ///     of no value unless you enable docs for the builder type with `#[builder(doc)]` or similar on
 ///     the type.
 ///
@@ -179,12 +179,12 @@ fn impl_my_derive(ast: &syn::DeriveInput) -> Result<TokenStream, Error> {
     Ok(data)
 }
 
-// It’d be nice for the compilation tests to live in tests/ with the rest, but short of pulling in
+// It'd be nice for the compilation tests to live in tests/ with the rest, but short of pulling in
 // some other test runner for that purpose (e.g. compiletest_rs), rustdoc compile_fail in this
 // crate is all we can use.
 
 #[doc(hidden)]
-/// When a property is skipped, you can’t set it:
+/// When a property is skipped, you can't set it:
 /// (“method `y` not found for this”)
 ///
 /// ```compile_fail

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -486,7 +486,7 @@ impl<'a> StructInfo<'a> {
         let helper_trait_name = &self.conversion_helper_trait_name;
         // The default of a field can refer to earlier-defined fields, which we handle by
         // writing out a bunch of `let` statements first, which can each refer to earlier ones.
-        // This means that field ordering may actually be significant, which isn’t ideal. We could
+        // This means that field ordering may actually be significant, which isn't ideal. We could
         // relax that restriction by calculating a DAG of field default dependencies and
         // reordering based on that, but for now this much simpler thing is a reasonable approach.
         let assignments = self.fields.iter().map(|field| {
@@ -506,7 +506,7 @@ impl<'a> StructInfo<'a> {
             match self.builder_attr.build_method_doc {
                 Some(ref doc) => quote!(#[doc = #doc]),
                 None => {
-                    // I’d prefer “a” or “an” to “its”, but determining which is grammatically
+                    // I'd prefer “a” or “an” to “its”, but determining which is grammatically
                     // correct is roughly impossible.
                     let doc = format!("Finalise the builder and create its [`{}`] instance", name);
                     quote!(#[doc = #doc])

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -137,11 +137,11 @@ impl<'a> StructInfo<'a> {
         Ok(quote! {
             impl #impl_generics #name #ty_generics #where_clause {
                 #[doc = #builder_method_doc]
-                #[allow(dead_code)]
+                #[allow(dead_code, clippy::default_trait_access)]
                 #vis fn builder() -> #builder_name #generics_with_empty {
                     #builder_name {
                         fields: #empties_tuple,
-                        phantom: core::default::Default::default(),
+                        phantom: ::core::default::Default::default(),
                     }
                 }
             }
@@ -155,10 +155,11 @@ impl<'a> StructInfo<'a> {
             }
 
             impl #b_generics_impl Clone for #builder_name #b_generics_ty #b_generics_where {
+                #[allow(clippy::default_trait_access)]
                 fn clone(&self) -> Self {
                     Self {
                         fields: self.fields.clone(),
-                        phantom: Default::default(),
+                        phantom: ::core::default::Default::default(),
                     }
                 }
             }
@@ -519,6 +520,7 @@ impl<'a> StructInfo<'a> {
             #[allow(dead_code, non_camel_case_types, missing_docs)]
             impl #impl_generics #builder_name #modified_ty_generics #where_clause {
                 #doc
+                #[allow(clippy::default_trait_access)]
                 pub fn build(self) -> #name #ty_generics {
                     let ( #(#descructuring,)* ) = self.fields;
                     #( #assignments )*

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -141,7 +141,7 @@ impl<'a> StructInfo<'a> {
                 #vis fn builder() -> #builder_name #generics_with_empty {
                     #builder_name {
                         fields: #empties_tuple,
-                        _phantom: core::default::Default::default(),
+                        phantom: core::default::Default::default(),
                     }
                 }
             }
@@ -151,14 +151,14 @@ impl<'a> StructInfo<'a> {
             #[allow(dead_code, non_camel_case_types, non_snake_case)]
             #vis struct #builder_name #b_generics {
                 fields: #all_fields_param,
-                _phantom: (#( #phantom_generics ),*),
+                phantom: (#( #phantom_generics ),*),
             }
 
             impl #b_generics_impl Clone for #builder_name #b_generics_ty #b_generics_where {
                 fn clone(&self) -> Self {
                     Self {
                         fields: self.fields.clone(),
-                        _phantom: Default::default(),
+                        phantom: Default::default(),
                     }
                 }
             }
@@ -305,7 +305,7 @@ impl<'a> StructInfo<'a> {
                     let ( #(#descructuring,)* ) = self.fields;
                     #builder_name {
                         fields: ( #(#reconstructing,)* ),
-                        _phantom: self._phantom,
+                        phantom: self.phantom,
                     }
                 }
             }

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::pedantic)]
 #![no_std]
 
 use typed_builder::TypedBuilder;
@@ -44,7 +45,7 @@ fn test_into() {
         x: i32,
     }
 
-    assert!(Foo::builder().x(1u8).build() == Foo { x: 1 });
+    assert!(Foo::builder().x(1_u8).build() == Foo { x: 1 });
 }
 
 #[test]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -75,7 +75,7 @@ fn test_into() {
         x: i32,
     }
 
-    assert!(Foo::builder().x(1u8).build() == Foo { x: 1 });
+    assert!(Foo::builder().x(1_u8).build() == Foo { x: 1 });
 }
 
 #[test]
@@ -86,7 +86,7 @@ fn test_strip_option_with_into() {
         x: Option<i32>,
     }
 
-    assert!(Foo::builder().x(1u8).build() == Foo { x: Some(1) });
+    assert!(Foo::builder().x(1_u8).build() == Foo { x: Some(1) });
 }
 
 #[test]
@@ -97,7 +97,7 @@ fn test_into_with_strip_option() {
         x: Option<i32>,
     }
 
-    assert!(Foo::builder().x(1u8).build() == Foo { x: Some(1) });
+    assert!(Foo::builder().x(1_u8).build() == Foo { x: Some(1) });
 }
 
 #[test]
@@ -222,7 +222,7 @@ fn test_skip() {
         z: i32,
     }
 
-    assert!(Foo::builder().y(1u8).build() == Foo { x: 0, y: 1, z: 2 });
+    assert!(Foo::builder().y(1_u8).build() == Foo { x: 0, y: 1, z: 2 });
 }
 
 #[test]
@@ -310,6 +310,7 @@ fn test_builder_type_stability_with_other_generics() {
 }
 
 #[test]
+#[allow(clippy::items_after_statements)]
 fn test_builder_type_with_default_on_generic_type() {
     #[derive(PartialEq, TypedBuilder)]
     struct Types<X, Y = ()> {
@@ -473,6 +474,7 @@ fn test_clone_builder() {
 }
 
 #[test]
+#[allow(clippy::items_after_statements)]
 fn test_clone_builder_with_generics() {
     #[derive(PartialEq, Default)]
     struct Uncloneable;

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -239,7 +239,7 @@ fn test_docs() {
         #[builder(
                 default = x,
                 setter(
-                    doc = "Set `z`. If you don’t specify a value it’ll default to the value specified for `x`.",
+                    doc = "Set `z`. If you don't specify a value it'll default to the value specified for `x`.",
                 ),
             )]
         #[allow(dead_code)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -1,3 +1,4 @@
+#![warn(clippy::pedantic)]
 #![allow(clippy::blacklisted_name, clippy::type_complexity)]
 
 use typed_builder::TypedBuilder;


### PR DESCRIPTION
I was having some trouble with pedantic Clippy warnings that seemed hard to fix on my end (as they appear to leak through `Span::mixed_site()` on the `#[derive(TypedBuilder)]` in my outer macro), so I made the adjustments here.

Avoiding those warnings doesn't seem to be part of the existing features, so please consider this a feature request.
I've added a `#![warn(clippy::pedantic)]` to `tests.rs` and `no_std.rs` in that regard, which should be enough to catch any of these issues in the future.

By doing so, I've also noticed that this repository had right single quotation marks `’` in place of apostrophes `'` in parts of the documentation. I've replaced them globally since they were only in contractions.

- - -

# Notable changes

I've added `#[allow(clippy::default_trait_access)]` on a few generated methods, which I *think* may be a breaking change for consumers that use `#[forbid(clippy::default_trait_access)]`.

I also fully qualified the `Default` trait access in question, since I noticed this was somewhat inconsistent.
This shouldn't affect consumers unless they were (ab)using a custom `Default` trait to inject code into the `build`, `builder` or `clone` functions, so I personally consider that a non-breaking patch.