### PR TITLE
Fix a typo in `CHANGELOG.md`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `#[builder(setter(strip_option))]` for making zero arguments setters for `bool` fields that just
+- `#[builder(setter(strip_bool))]` for making zero arguments setters for `bool` fields that just
   set them to `true` (the `default` automatically becomes `false`)
 
 ## 0.9.1 - 2021-09-04


### PR DESCRIPTION
Thank you for quickly implementing the feature request #60.
I found a typo in the `CHANGELOG.md` that committed in b3cf29badff9b02bd0f9953464b01a18e304c7e2, this PR fixed it.