### PR TITLE
feat: add struct attr to replace `build` method with a private method 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `#[builder(build_method(vis="pub", name=build))]` for customizing visibility and fn name of the final build method
+  (the default visibility is `pub`, and default build name is `build`)
 
 ## 0.10.0 - 2022-02-13
 ### Added

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Foo::builder().x(1).y(2).y(3); // y is specified twice
 * Compile time verification that no field is set more than once.
 * Ability to annotate fields with `#[builder(default)]` to make them optional and specify a default value when the user does not set them.
 * Generates simple documentation for the `.builder()` method.
+* Customizable method name and visibility of the `.build()` method.
 
 ## Limitations
 

--- a/examples/complicate_build.rs
+++ b/examples/complicate_build.rs
@@ -1,0 +1,54 @@
+mod scope {
+    use typed_builder::TypedBuilder;
+
+    #[derive(PartialEq, TypedBuilder)]
+    #[builder(build_method(vis="", name=__build))]
+    pub struct Foo {
+        // Mandatory Field:
+        x: i32,
+
+        // #[builder(default)] without parameter - use the type's default
+        // #[builder(setter(strip_option))] - wrap the setter argument with `Some(...)`
+        #[builder(default, setter(strip_option))]
+        y: Option<i32>,
+
+        // Or you can set the default
+        #[builder(default = 20)]
+        z: i32,
+    }
+
+    // Customize build method to add complicated logic.
+    //
+    // The signature might be frightening at first glance,
+    // but we don't need to infer this whole ourselves.
+    //
+    // We can use `cargo expand` to show code expanded by `TypedBuilder`,
+    // copy the generated `__build` method, and modify the content of the build method.
+    #[allow(non_camel_case_types)]
+    impl<__z: FooBuilder_Optional<i32>, __y: FooBuilder_Optional<Option<i32>>> FooBuilder<((i32,), __y, __z)> {
+        pub fn build(self) -> Bar {
+            let foo = self.__build();
+            Bar {
+                x: foo.x + 1,
+                y: foo.y.map(|y| y + 1),
+                z: foo.z + 1,
+            }
+        }
+    }
+
+    #[derive(PartialEq)]
+    pub struct Bar {
+        pub x: i32,
+        pub y: Option<i32>,
+        pub z: i32,
+    }
+}
+
+use scope::{Bar, Foo};
+
+fn main() {
+    assert!(Foo::builder().x(1).y(2).z(3).build() == Bar { x: 2, y: Some(3), z: 4 });
+
+    // This will not compile - because `__build` is a private method
+    // Foo::builder().x(1).y(2).z(3).__build()
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,6 +74,10 @@ mod util;
 ///   but it won't be a link. If you turn this on, the builder type and its `build` method will get
 ///   sane defaults. The field methods on the builder will be undocumented by default.
 ///
+/// - `build_method(...)`: customize the final build method
+///   - `vis = "…"`: sets the visibility of the build method, default is `pub`
+///   - `name = …`: sets the fn name of the build method, default is `build`
+///
 /// - `builder_method_doc = "…"` replaces the default documentation that will be generated for the
 ///   `builder()` method of the type for which the builder is being generated.
 ///

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -520,17 +520,27 @@ impl<'a> StructInfo<'a> {
         } else {
             quote!()
         };
-        let (access, build_method_name) = if self.builder_attr.private_build_method {
-            (quote!(pub(crate)), quote!(__build))
-        } else {
-            (quote!(pub), quote!(build))
-        };
+
+        let build_method_name = self
+            .builder_attr
+            .build_method
+            .name
+            .as_ref()
+            .map(|name| quote!(#name))
+            .unwrap_or(quote!(build));
+        let visibility = self
+            .builder_attr
+            .build_method
+            .vis
+            .as_ref()
+            .map(|v| quote!(#v))
+            .unwrap_or(quote!(pub));
         quote!(
             #[allow(dead_code, non_camel_case_types, missing_docs)]
             impl #impl_generics #builder_name #modified_ty_generics #where_clause {
                 #doc
                 #[allow(clippy::default_trait_access)]
-                #access fn #build_method_name(self) -> #name #ty_generics {
+                #visibility fn #build_method_name(self) -> #name #ty_generics {
                     let ( #(#descructuring,)* ) = self.fields;
                     #( #assignments )*
                     #name {
@@ -542,13 +552,48 @@ impl<'a> StructInfo<'a> {
     }
 }
 
+#[derive(Debug, Default, Clone)]
+pub struct BuildMethodSettings {
+    pub vis: Option<syn::Visibility>,
+    pub name: Option<syn::Expr>,
+}
+impl BuildMethodSettings {
+    fn apply_meta(&mut self, expr: syn::Expr) -> Result<(), Error> {
+        match expr {
+            syn::Expr::Assign(assign) => {
+                let name =
+                    expr_to_single_string(&assign.left).ok_or_else(|| Error::new_spanned(&assign.left, "Expected identifier"))?;
+                match name.as_str() {
+                    "vis" => {
+                        if let syn::Expr::Lit(expr_lit) = &*assign.right {
+                            if let syn::Lit::Str(ref s) = expr_lit.lit {
+                                self.vis = Some(syn::parse_str(&s.value()).expect("invalid visibility found"));
+                            }
+                        }
+                        if self.vis.is_none() {
+                            panic!("invalid visibility found")
+                        }
+                        Ok(())
+                    }
+                    "name" => {
+                        self.name = Some(*assign.right);
+                        Ok(())
+                    }
+                    _ => Err(Error::new_spanned(&assign, format!("Unknown parameter {:?}", name))),
+                }
+            }
+            _ => Err(Error::new_spanned(expr, "Expected (<...>=<...>)")),
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct TypeBuilderAttr {
     /// Whether to show docs for the `TypeBuilder` type (rather than hiding them).
     pub doc: bool,
 
-    /// Whether to generate a private `pub(crate) __build()` method instead of `pub build()` method
-    pub private_build_method: bool,
+    /// Customize build method, ex. visitability, name
+    pub build_method: BuildMethodSettings,
 
     /// Docs on the `Type::builder()` method.
     pub builder_method_doc: Option<syn::Expr>,
@@ -625,10 +670,6 @@ impl TypeBuilderAttr {
                         self.doc = true;
                         Ok(())
                     }
-                    "private_build_method" => {
-                        self.private_build_method = true;
-                        Ok(())
-                    }
                     _ => Err(Error::new_spanned(&path, format!("Unknown parameter {:?}", name))),
                 }
             }
@@ -647,6 +688,12 @@ impl TypeBuilderAttr {
                     "field_defaults" => {
                         for arg in call.args {
                             self.field_defaults.apply_meta(arg)?;
+                        }
+                        Ok(())
+                    }
+                    "build_method" => {
+                        for arg in call.args {
+                            self.build_method.apply_meta(arg)?;
                         }
                         Ok(())
                     }

--- a/src/struct_info.rs
+++ b/src/struct_info.rs
@@ -592,7 +592,7 @@ pub struct TypeBuilderAttr {
     /// Whether to show docs for the `TypeBuilder` type (rather than hiding them).
     pub doc: bool,
 
-    /// Customize build method, ex. visitability, name
+    /// Customize build method, ex. visibility, name
     pub build_method: BuildMethodSettings,
 
     /// Docs on the `Type::builder()` method.

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -563,3 +563,14 @@ fn test_field_setter_transform() {
             }
     );
 }
+
+#[test]
+fn test_build_method() {
+    #[derive(PartialEq, TypedBuilder)]
+    #[builder(build_method(vis="", name=__build))]
+    struct Foo {
+        x: i32,
+    }
+
+    assert!(Foo::builder().x(1).__build() == Foo { x: 1 });
+}


### PR DESCRIPTION
Instead of generating a public `build` method, we can generate a private `build` method with a name like `__build()`. With this, users can write a custom build method with complicated logic and even build into another `struct`.  
##  Example

### Normal case: generate pub `build` method

Say we have a struct `Foo` as following:
```rust
#[derive(PartialEq, TypedBuilder)]
struct Foo {
    x: i32,

    #[builder(default, setter(strip_option))]
    y: Option<i32>,

    #[builder(default = 20)]
    z: i32,
}
```
This is taken from `example/example.rs`.

The above code will generated a build method as following:

```rust
#[allow(dead_code, non_camel_case_types, missing_docs)]
impl<
    __z: FooBuilder_Optional<i32>,
    __y: FooBuilder_Optional<Option<i32>>,
> FooBuilder<((i32,), __y, __z)> {
    #[allow(clippy::default_trait_access)]
    pub fn build(self) -> Foo {
        let (x, y, z) = self.fields;
        let x = x.0;
        let y = FooBuilder_Optional::into_value(
            y,
            || ::core::default::Default::default(),
        );
        let z = FooBuilder_Optional::into_value(z, || 20);
        Foo { x, y, z }
    }
}
```
However, this default `build` implementation is quite simple and impossible to build into another `struct`.

### Generate a private `__build` method and impl custom build method
Now we set the new struct attr `build_method`:

```rust
#[derive(PartialEq, TypedBuilder)]
#[builder(build_method(vis="pub(crate)", name=__build))) // HERE
struct Foo {
    x: i32,

    #[builder(default, setter(strip_option))]
    y: Option<i32>,

    #[builder(default = 20)]
    z: i32,
}
```
The above code will generated a private method as following:
```rust
#[allow(dead_code, non_camel_case_types, missing_docs)]
impl<
    __z: FooBuilder_Optional<i32>,
    __y: FooBuilder_Optional<Option<i32>>,
> FooBuilder<((i32,), __y, __z)> {
    #[allow(clippy::default_trait_access)]
    pub(crate) fn __build(self) -> Foo { // Here is the difference
        let (x, y, z) = self.fields;
        let x = x.0;
        let y = FooBuilder_Optional::into_value(
            y,
            || ::core::default::Default::default(),
        );
        let z = FooBuilder_Optional::into_value(z, || 20);
        Foo { x, y, z }
    }
}
```

Now we can impl custom build method:

```rust
#[allow(non_camel_case_types)]
impl<
    __z: FooBuilder_Optional<i32>,
    __y: FooBuilder_Optional<Option<i32>>,
> FooBuilder<((i32,), __y, __z)> {
    pub fn build(self) -> Result<Bar, std::io::Error> {
        let foo = self.__build();
        // add custom code, whether to check or transform data
        Ok(Bar { foo.x, foo.y, foo.z })
    }
}
```
Note that the above code is not generated by this macro and we have to manually write these boilerplate code. We don't need to infer these generics ourself, we can use `cargo expand` to copy the implementation of `__build()` and modify it.

## On custom build method

Without this PR, we can also use this pattern to generate custom method to build struct. But the `build` method is already defined and we have to use another name like `finish()` or so. In this way, we have both `build()` and `finish()`, which can cause confusion. Even more so if the custom `finish` share a same signature with `build()`, in which we cannot detect the problem in compile time.