### PR TITLE
Upgrade syn to 2.x

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,6 @@ categories = ["rust-patterns"]
 proc-macro = true
 
 [dependencies]
-syn = { version = "1", features = ["full", "extra-traits"] }
+syn = { version = "2", features = ["full", "extra-traits"] }
 quote = "1"
 proc-macro2 = "1"


### PR DESCRIPTION
Closes https://github.com/idanarye/rust-typed-builder/issues/85

There is one change: `#[builder]` and `#[builder = …]` are now just ignored.

We could throw an error by adding the two missing arms to the match of `attr.meta` and then checking the path, but I don't think that we should waste this (minimal) performance on checking attributes that are probably not related to typed-builder.