### PR TITLE
WIP: Optimizations

### DIFF
--- a/src/util.rs
+++ b/src/util.rs
@@ -73,8 +73,8 @@ pub fn modify_types_generics_hack<F>(ty_generics: &syn::TypeGenerics, mut mutato
 where
     F: FnMut(&mut syn::punctuated::Punctuated<syn::GenericArgument, syn::token::Comma>),
 {
-    let mut abga: syn::AngleBracketedGenericArguments = syn::parse(ty_generics.clone().into_token_stream().into())
-        .unwrap_or_else(|_| syn::AngleBracketedGenericArguments {
+    let mut abga: syn::AngleBracketedGenericArguments =
+        syn::parse2(ty_generics.to_token_stream()).unwrap_or_else(|_| syn::AngleBracketedGenericArguments {
             colon2_token: None,
             lt_token: Default::default(),
             args: Default::default(),

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -504,7 +504,7 @@ fn test_clone_builder_with_generics() {
     let semi_built2 = Foo::builder().x("four");
 
     assert!(semi_built2.clone().y(5).build() == Foo { x: "four", y: 5 });
-    assert!(semi_built2.clone().y(6).build() == Foo { x: "four", y: 6 });
+    assert!(semi_built2.y(6).build() == Foo { x: "four", y: 6 });
 
     // Just to make sure it can build with generic bounds
     #[allow(dead_code)]


### PR DESCRIPTION
Use `parse2` instead of `parse`. Never convert `proc_macro2::TokenStream` into `proc_macro::TokenStream` for using `parse` since it converts `proc_macro::TokenStream` back into `proc_macro2::TokenStream` and then calls `parse2`: https://github.com/dtolnay/syn/blob/2a001f4ba32eccda0063c4426cab84abbd4d11aa/src/parse.rs#L1201