### PR TITLE
Use Rust 1.70 in stable for parse index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        rust: [1.69.0, nightly]
+        rust: [1.70.0, nightly]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
If you take a look at the latest CI tests in other PRs, nightly is 10 times faster. This is because of the sparse index that is the default in Rust 1.70