### PR TITLE
feat: add support for setter prefix and suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   setter for that field now does.
 
 ### Added
-- Support for setter method pre- and suffixes `#[builder(field_defaults(setter(prefix = "...", suffix = "...")))]`.
+- Support for setter method prefixes and suffixes `#[builder(field_defaults(setter(prefix = "...", suffix = "...")))]`.
   This either prepends or appends the provided string to the setter method. This allows method names like: `set_x()`,
   `with_y()`, or `set_z_value()`.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
   generated code itself does trigger the deprecation warning, and instead the
   setter for that field now does.
 
+### Added
+- Support for setter method pre- and suffixes `#[builder(field_defaults(setter(prefix = "...", suffix = "...")))]`.
+  This either prepends or appends the provided string to the setter method. This allows method names like: `set_x()`,
+  `with_y()`, or `set_z_value()`.
+
 ## 0.14.0 - 2023-03-08
 ### Added
 - `build_method(into)` and `build_method(into = ...)`.

--- a/examples/complicate_build.rs
+++ b/examples/complicate_build.rs
@@ -1,7 +1,7 @@
 mod scope {
     use typed_builder::TypedBuilder;
 
-    #[derive(PartialEq, TypedBuilder)]
+    #[derive(Debug, PartialEq, TypedBuilder)]
     #[builder(build_method(vis="", name=__build))]
     pub struct Foo {
         // Mandatory Field:
@@ -36,7 +36,7 @@ mod scope {
         }
     }
 
-    #[derive(PartialEq)]
+    #[derive(Debug, PartialEq)]
     pub struct Bar {
         pub x: i32,
         pub y: Option<i32>,
@@ -47,7 +47,7 @@ mod scope {
 use scope::{Bar, Foo};
 
 fn main() {
-    assert!(Foo::builder().x(1).y(2).z(3).build() == Bar { x: 2, y: Some(3), z: 4 });
+    assert_eq!(Foo::builder().x(1).y(2).z(3).build(), Bar { x: 2, y: Some(3), z: 4 });
 
     // This will not compile - because `__build` is a private method
     // Foo::builder().x(1).y(2).z(3).__build()

--- a/examples/example.rs
+++ b/examples/example.rs
@@ -1,6 +1,6 @@
 use typed_builder::TypedBuilder;
 
-#[derive(PartialEq, TypedBuilder)]
+#[derive(Debug, PartialEq, TypedBuilder)]
 struct Foo {
     // Mandatory Field:
     x: i32,
@@ -16,13 +16,13 @@ struct Foo {
 }
 
 fn main() {
-    assert!(Foo::builder().x(1).y(2).z(3).build() == Foo { x: 1, y: Some(2), z: 3 });
+    assert_eq!(Foo::builder().x(1).y(2).z(3).build(), Foo { x: 1, y: Some(2), z: 3 });
 
     // Change the order of construction:
-    assert!(Foo::builder().z(1).x(2).y(3).build() == Foo { x: 2, y: Some(3), z: 1 });
+    assert_eq!(Foo::builder().z(1).x(2).y(3).build(), Foo { x: 2, y: Some(3), z: 1 });
 
     // Optional fields are optional:
-    assert!(Foo::builder().x(1).build() == Foo { x: 1, y: None, z: 20 });
+    assert_eq!(Foo::builder().x(1).build(), Foo { x: 1, y: None, z: 20 });
 
     // This will not compile - because we did not set x:
     // Foo::builder().build();

--- a/examples/example_prefix_suffix.rs
+++ b/examples/example_prefix_suffix.rs
@@ -1,7 +1,7 @@
 use typed_builder::TypedBuilder;
 
 #[derive(Debug, PartialEq, TypedBuilder)]
-#[builder(field_defaults(setter(prefix = "with", suffix = "value")))]
+#[builder(field_defaults(setter(prefix = "with_", suffix = "_value")))]
 struct Foo {
     // Mandatory Field:
     x: i32,

--- a/examples/example_prefix_suffix.rs
+++ b/examples/example_prefix_suffix.rs
@@ -1,0 +1,39 @@
+use typed_builder::TypedBuilder;
+
+#[derive(Debug, PartialEq, TypedBuilder)]
+#[builder(field_defaults(setter(prefix = "with", suffix = "value")))]
+struct Foo {
+    // Mandatory Field:
+    x: i32,
+
+    // #[builder(default)] without parameter - use the type's default
+    // #[builder(setter(strip_option))] - wrap the setter argument with `Some(...)`
+    #[builder(default, setter(strip_option))]
+    y: Option<i32>,
+
+    // Or you can set the default
+    #[builder(default = 20)]
+    z: i32,
+}
+
+fn main() {
+    assert_eq!(
+        Foo::builder().with_x_value(1).with_y_value(2).with_z_value(3).build(),
+        Foo { x: 1, y: Some(2), z: 3 }
+    );
+
+    // Change the order of construction:
+    assert_eq!(
+        Foo::builder().with_z_value(1).with_x_value(2).with_y_value(3).build(),
+        Foo { x: 2, y: Some(3), z: 1 }
+    );
+
+    // Optional fields are optional:
+    assert_eq!(Foo::builder().with_x_value(1).build(), Foo { x: 1, y: None, z: 20 });
+
+    // This will not compile - because we did not set x:
+    // Foo::builder().build();
+
+    // This will not compile - because we set y twice:
+    // Foo::builder().with_x_value(1).with_y_value(2).with_y_value(3);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,11 +150,11 @@
 ///     when the setter is called.
 ///
 ///   - `prefix = "..."` prepends the setter method with the specified prefix. For example, setting
-///     `prefix = "with"` results in setters like `with_x` or `with_y`. This option is combinable
+///     `prefix = "with_"` results in setters like `with_x` or `with_y`. This option is combinable
 ///     with `suffix = "..."`.
 ///
 ///   - `suffix = "..."` appends the setter method with the specified suffix. For example, setting
-///     `suffix = "value"` results in setters like `x_value` or `y_value`. This option is combinable
+///     `suffix = "_value"` results in setters like `x_value` or `y_value`. This option is combinable
 ///     with `prefix = "..."`.
 pub use typed_builder_macro::TypedBuilder;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -48,7 +48,7 @@
 /// // Foo::builder().x(1).y(2).y(3);
 /// ```
 ///
-/// # Customisation with attributes
+/// # Customization with attributes
 ///
 /// In addition to putting `#[derive(TypedBuilder)]` on a type, you can specify a `#[builder(…)]`
 /// attribute on the type, and on any fields in it.
@@ -148,6 +148,14 @@
 ///     `param1: Type1, param2: Type2 ...` instead of the field type itself. The parameters are
 ///     transformed into the field type using the expression `expr`. The transformation is performed
 ///     when the setter is called.
+///
+///   - `prefix = "..."` prepends the setter method with the specified prefix. For example, setting
+///     `prefix = "with"` results in setters like `with_x` or `with_y`. This option is combinable
+///     with `suffix = "..."`.
+///
+///   - `suffix = "..."` appends the setter method with the specified suffix. For example, setting
+///     `suffix = "value"` results in setters like `x_value` or `y_value`. This option is combinable
+///     with `prefix = "..."`.
 pub use typed_builder_macro::TypedBuilder;
 
 #[doc(hidden)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -543,6 +543,32 @@ fn test_builder_on_struct_with_keywords() {
 }
 
 #[test]
+fn test_builder_on_struct_with_keywords_prefix_suffix() {
+    #[allow(non_camel_case_types)]
+    #[derive(PartialEq, TypedBuilder)]
+    #[builder(field_defaults(setter(prefix = "set_", suffix = "_value")))]
+    struct r#struct {
+        r#fn: u32,
+        #[builder(default, setter(strip_option))]
+        r#type: Option<u32>,
+        #[builder(default = Some(()), setter(skip))]
+        r#enum: Option<()>,
+        #[builder(setter(into))]
+        r#union: String,
+    }
+
+    assert!(
+        r#struct::builder().r#set_fn_value(1).r#set_union_value("two").build()
+            == r#struct {
+                r#fn: 1,
+                r#type: None,
+                r#enum: Some(()),
+                r#union: "two".to_owned(),
+            }
+    );
+}
+
+#[test]
 fn test_field_setter_transform() {
     #[derive(PartialEq)]
     struct Point {

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -671,3 +671,42 @@ fn test_into_set_generic_impl_into() {
     let bar: Bar = Foo::builder().value(42).build();
     assert_eq!(bar, Bar { value: 42 });
 }
+
+#[test]
+fn test_prefix() {
+    #[derive(Debug, PartialEq, TypedBuilder)]
+    #[builder(field_defaults(setter(prefix = "with")))]
+    struct Foo {
+        x: i32,
+        y: i32,
+    }
+
+    let foo = Foo::builder().with_x(1).with_y(2).build();
+    assert_eq!(foo, Foo { x: 1, y: 2 })
+}
+
+#[test]
+fn test_suffix() {
+    #[derive(Debug, PartialEq, TypedBuilder)]
+    #[builder(field_defaults(setter(suffix = "value")))]
+    struct Foo {
+        x: i32,
+        y: i32,
+    }
+
+    let foo = Foo::builder().x_value(1).y_value(2).build();
+    assert_eq!(foo, Foo { x: 1, y: 2 })
+}
+
+#[test]
+fn test_prefix_and_suffix() {
+    #[derive(Debug, PartialEq, TypedBuilder)]
+    #[builder(field_defaults(setter(prefix = "with", suffix = "value")))]
+    struct Foo {
+        x: i32,
+        y: i32,
+    }
+
+    let foo = Foo::builder().with_x_value(1).with_y_value(2).build();
+    assert_eq!(foo, Foo { x: 1, y: 2 })
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -675,7 +675,7 @@ fn test_into_set_generic_impl_into() {
 #[test]
 fn test_prefix() {
     #[derive(Debug, PartialEq, TypedBuilder)]
-    #[builder(field_defaults(setter(prefix = "with")))]
+    #[builder(field_defaults(setter(prefix = "with_")))]
     struct Foo {
         x: i32,
         y: i32,
@@ -688,7 +688,7 @@ fn test_prefix() {
 #[test]
 fn test_suffix() {
     #[derive(Debug, PartialEq, TypedBuilder)]
-    #[builder(field_defaults(setter(suffix = "value")))]
+    #[builder(field_defaults(setter(suffix = "_value")))]
     struct Foo {
         x: i32,
         y: i32,
@@ -701,7 +701,7 @@ fn test_suffix() {
 #[test]
 fn test_prefix_and_suffix() {
     #[derive(Debug, PartialEq, TypedBuilder)]
-    #[builder(field_defaults(setter(prefix = "with", suffix = "value")))]
+    #[builder(field_defaults(setter(prefix = "with_", suffix = "_value")))]
     struct Foo {
         x: i32,
         y: i32,

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -4,6 +4,7 @@ use syn::{parse::Error, spanned::Spanned};
 
 use crate::util::{
     apply_subsections, expr_to_lit_string, expr_to_single_string, ident_to_type, path_to_single_string, strip_raw_ident_prefix,
+    strip_raw_ident_prefix_with_status,
 };
 
 #[derive(Debug)]
@@ -76,14 +77,22 @@ impl<'a> FieldInfo<'a> {
     }
 
     pub fn setter_method_name(&self) -> Ident {
-        if let (Some(prefix), Some(suffix)) = (&self.builder_attr.setter.prefix, &self.builder_attr.setter.suffix) {
-            Ident::new(&format!("{}{}{}", prefix, self.name, suffix), proc_macro2::Span::call_site())
+        let (name, was_stripped) = strip_raw_ident_prefix_with_status(self.name.to_string());
+
+        let ident = if let (Some(prefix), Some(suffix)) = (&self.builder_attr.setter.prefix, &self.builder_attr.setter.suffix) {
+            format!("{}{}{}", prefix, name, suffix)
         } else if let Some(prefix) = &self.builder_attr.setter.prefix {
-            Ident::new(&format!("{}{}", prefix, self.name), proc_macro2::Span::call_site())
+            format!("{}{}", prefix, name)
         } else if let Some(suffix) = &self.builder_attr.setter.suffix {
-            Ident::new(&format!("{}{}", self.name, suffix), proc_macro2::Span::call_site())
+            format!("{}{}", name, suffix)
         } else {
-            self.name.clone()
+            name
+        };
+
+        if was_stripped {
+            Ident::new_raw(&ident, Span::call_site())
+        } else {
+            Ident::new(&ident, Span::call_site())
         }
     }
 

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -4,7 +4,6 @@ use syn::{parse::Error, spanned::Spanned};
 
 use crate::util::{
     apply_subsections, expr_to_lit_string, expr_to_single_string, ident_to_type, path_to_single_string, strip_raw_ident_prefix,
-    strip_raw_ident_prefix_with_status,
 };
 
 #[derive(Debug)]
@@ -77,22 +76,16 @@ impl<'a> FieldInfo<'a> {
     }
 
     pub fn setter_method_name(&self) -> Ident {
-        let (name, was_stripped) = strip_raw_ident_prefix_with_status(self.name.to_string());
+        let name = strip_raw_ident_prefix(self.name.to_string());
 
-        let ident = if let (Some(prefix), Some(suffix)) = (&self.builder_attr.setter.prefix, &self.builder_attr.setter.suffix) {
-            format!("{}{}{}", prefix, name, suffix)
+        if let (Some(prefix), Some(suffix)) = (&self.builder_attr.setter.prefix, &self.builder_attr.setter.suffix) {
+            Ident::new(&format!("{}{}{}", prefix, name, suffix), Span::call_site())
         } else if let Some(prefix) = &self.builder_attr.setter.prefix {
-            format!("{}{}", prefix, name)
+            Ident::new(&format!("{}{}", prefix, name), Span::call_site())
         } else if let Some(suffix) = &self.builder_attr.setter.suffix {
-            format!("{}{}", name, suffix)
+            Ident::new(&format!("{}{}", name, suffix), Span::call_site())
         } else {
-            name
-        };
-
-        if was_stripped {
-            Ident::new_raw(&ident, Span::call_site())
-        } else {
-            Ident::new(&ident, Span::call_site())
+            Ident::new_raw(&name, Span::call_site())
         }
     }
 

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -85,7 +85,7 @@ impl<'a> FieldInfo<'a> {
         } else if let Some(suffix) = &self.builder_attr.setter.suffix {
             Ident::new(&format!("{}{}", name, suffix), Span::call_site())
         } else {
-            Ident::new_raw(&name, Span::call_site())
+            self.name.clone()
         }
     }
 

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -110,6 +110,8 @@ pub struct SetterSettings {
     pub strip_option: Option<Span>,
     pub strip_bool: Option<Span>,
     pub transform: Option<Transform>,
+    pub prefix: Option<syn::Expr>,
+    pub suffix: Option<syn::Expr>,
 }
 
 impl<'a> FieldBuilderAttr<'a> {
@@ -284,6 +286,14 @@ impl SetterSettings {
                     }
                     "transform" => {
                         self.transform = Some(parse_transform_closure(assign.left.span(), *assign.right)?);
+                        Ok(())
+                    }
+                    "prefix" => {
+                        self.prefix = Some(*assign.right);
+                        Ok(())
+                    }
+                    "suffix" => {
+                        self.suffix = Some(*assign.right);
                         Ok(())
                     }
                     _ => Err(Error::new_spanned(&assign, format!("Unknown parameter {:?}", name))),

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -262,7 +262,7 @@ impl<'a> StructInfo<'a> {
         );
         let repeated_fields_error_message = format!("Repeated field {}", field_name);
 
-        let method_name = Self::method_name(field, field_name)?;
+        let method_name = field.setter_method_name();
 
         Ok(quote! {
             #[allow(dead_code, non_camel_case_types, missing_docs)]
@@ -292,69 +292,6 @@ impl<'a> StructInfo<'a> {
                 }
             }
         })
-    }
-
-    fn method_name(field: &FieldInfo, field_name: &Ident) -> Result<Ident, Error> {
-        let prefix = match &field.builder_attr.setter.prefix {
-            Some(prefix) => match prefix {
-                syn::Expr::Lit(lit) => match &lit.lit {
-                    syn::Lit::Str(str) => Some(syn::Ident::new(&format!("{}", str.value()), proc_macro2::Span::call_site())),
-                    _ => {
-                        return Err(Error::new_spanned(
-                            prefix,
-                            "field_defaults(setter(prefix)) only allows str values",
-                        ))
-                    }
-                },
-                _ => {
-                    return Err(Error::new_spanned(
-                        prefix,
-                        "field_defaults(setter(prefix)) only allows str values",
-                    ))
-                }
-            },
-            None => None,
-        };
-
-        let suffix = match &field.builder_attr.setter.suffix {
-            Some(suffix) => match suffix {
-                syn::Expr::Lit(lit) => match &lit.lit {
-                    syn::Lit::Str(str) => Some(syn::Ident::new(&format!("{}", str.value()), proc_macro2::Span::call_site())),
-                    _ => {
-                        return Err(Error::new_spanned(
-                            suffix,
-                            "field_defaults(setter(suffix)) only allows str values",
-                        ))
-                    }
-                },
-                _ => {
-                    return Err(Error::new_spanned(
-                        suffix,
-                        "field_defaults(setter(suffix)) only allows str values",
-                    ))
-                }
-            },
-            None => None,
-        };
-
-        if let (Some(prefix), Some(suffix)) = (&prefix, &suffix) {
-            Ok(Ident::new(
-                &format!("{}_{}_{}", prefix, field_name, suffix),
-                proc_macro2::Span::call_site(),
-            ))
-        } else if let Some(prefix) = prefix {
-            Ok(Ident::new(
-                &format!("{}_{}", prefix, field_name),
-                proc_macro2::Span::call_site(),
-            ))
-        } else if let Some(suffix) = suffix {
-            Ok(Ident::new(
-                &format!("{}_{}", field_name, suffix),
-                proc_macro2::Span::call_site(),
-            ))
-        } else {
-            Ok(field_name.clone())
-        }
     }
 
     pub fn required_field_impl(&self, field: &FieldInfo) -> TokenStream {

--- a/typed-builder-macro/src/util.rs
+++ b/typed-builder-macro/src/util.rs
@@ -85,6 +85,17 @@ pub fn strip_raw_ident_prefix(mut name: String) -> String {
     name
 }
 
+pub fn strip_raw_ident_prefix_with_status(mut name: String) -> (String, bool) {
+    let len = name.len();
+    name = strip_raw_ident_prefix(name);
+
+    if name.len() < len {
+        (name, true)
+    } else {
+        (name, false)
+    }
+}
+
 pub fn first_visibility(visibilities: &[Option<&syn::Visibility>]) -> proc_macro2::TokenStream {
     let vis = visibilities
         .iter()

--- a/typed-builder-macro/src/util.rs
+++ b/typed-builder-macro/src/util.rs
@@ -1,5 +1,5 @@
 use quote::ToTokens;
-use syn::parse::Parser;
+use syn::{parse::Parser, Error};
 
 pub fn path_to_single_string(path: &syn::Path) -> Option<String> {
     if path.leading_colon.is_some() {
@@ -114,4 +114,14 @@ pub fn apply_subsections(
     }
 
     Ok(())
+}
+
+pub fn expr_to_lit_string(expr: &syn::Expr) -> Result<String, Error> {
+    match expr {
+        syn::Expr::Lit(lit) => match &lit.lit {
+            syn::Lit::Str(str) => Ok(str.value()),
+            _ => return Err(Error::new_spanned(expr, "attribute only allows str values")),
+        },
+        _ => return Err(Error::new_spanned(expr, "attribute only allows str values")),
+    }
 }

--- a/typed-builder-macro/src/util.rs
+++ b/typed-builder-macro/src/util.rs
@@ -85,17 +85,6 @@ pub fn strip_raw_ident_prefix(mut name: String) -> String {
     name
 }
 
-pub fn strip_raw_ident_prefix_with_status(mut name: String) -> (String, bool) {
-    let len = name.len();
-    name = strip_raw_ident_prefix(name);
-
-    if name.len() < len {
-        (name, true)
-    } else {
-        (name, false)
-    }
-}
-
 pub fn first_visibility(visibilities: &[Option<&syn::Visibility>]) -> proc_macro2::TokenStream {
     let vis = visibilities
         .iter()


### PR DESCRIPTION
This PR adds support to add prefixes and suffixes to setter methods.

```rust
#[derive(TypedBuilder)]
#[builder(field_defaults(setter(prefix = "with_", suffix = "_value")))]
struct Foo {
    x: i32,
    y: u32,
}

let foo = Foo::builder().with_x_value(1).with_y_value(2).build();
```