### PR TITLE
Fix private type leak

### DIFF
--- a/tests/no_type_leakage.rs
+++ b/tests/no_type_leakage.rs
@@ -1,0 +1,27 @@
+// As long as this test compiles, it passes (test does not occur at runtime)
+
+use typed_builder::TypedBuilder;
+
+#[derive(PartialEq, TypedBuilder)]
+#[builder(
+    build_method(vis="pub", into=Bar),
+    builder_method(vis=""),
+    builder_type(vis="pub", name=BarBuilder),
+)]
+struct Foo {
+    x: i32,
+}
+
+pub struct Bar(Foo);
+
+impl Bar {
+    pub fn builder() -> BarBuilder {
+        Foo::builder()
+    }
+}
+
+impl From<Foo> for Bar {
+    fn from(wrapped: Foo) -> Self {
+        Bar(wrapped)
+    }
+}

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -295,10 +295,7 @@ impl<'a> StructInfo<'a> {
     }
 
     pub fn required_field_impl(&self, field: &FieldInfo) -> TokenStream {
-        let StructInfo {
-            ref builder_name,
-            ..
-        } = self;
+        let StructInfo { ref builder_name, .. } = self;
 
         let FieldInfo {
             name: ref field_name, ..

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -296,7 +296,6 @@ impl<'a> StructInfo<'a> {
 
     pub fn required_field_impl(&self, field: &FieldInfo) -> TokenStream {
         let StructInfo {
-            ref name,
             ref builder_name,
             ..
         } = self;
@@ -355,7 +354,6 @@ impl<'a> StructInfo<'a> {
 
         builder_generics.push(syn::GenericArgument::Type(builder_generics_tuple.into()));
         let (impl_generics, _, where_clause) = generics.split_for_impl();
-        let (_, ty_generics, _) = self.generics.split_for_impl();
 
         let early_build_error_type_name = syn::Ident::new(
             &format!(
@@ -380,8 +378,8 @@ impl<'a> StructInfo<'a> {
                 #[deprecated(
                     note = #early_build_error_message
                 )]
-                #build_method_visibility fn #build_method_name(self, _: #early_build_error_type_name) -> #name #ty_generics {
-                    panic!();
+                #build_method_visibility fn #build_method_name(self, _: #early_build_error_type_name) -> ! {
+                    panic!()
                 }
             }
         }


### PR DESCRIPTION
This PR fixes a private type leak bug in the expanded macro output, by making a small simplification in the implementation.  I also added a test that triggers the bug.