### PR TITLE
Make repository into workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
-[package]
-name = "typed-builder"
+[workspace]
+members = [".", "./typed-builder-macro"]
+
+[workspace.package]
 description = "Compile-time type-checked builder derive"
 version = "0.14.0"
 authors = ["IdanArye <idanarye@gmail.com>", "Chris Morgan <me@chrismorgan.info>"]
@@ -11,5 +13,18 @@ readme = "README.md"
 keywords = ["builder"]
 categories = ["rust-patterns"]
 
+[package]
+name = "typed-builder"
+description.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+
 [dependencies]
-typed-builder-macro = { path = "typed-builder-macro", version = "=0.14.0"}
+typed-builder-macro = { path = "typed-builder-macro", version = "=0.14.0" }

--- a/typed-builder-macro/Cargo.toml
+++ b/typed-builder-macro/Cargo.toml
@@ -1,7 +1,15 @@
 [package]
 name = "typed-builder-macro"
-version = "0.14.0"
-edition = "2021"
+description.workspace = true
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+repository.workspace = true
+documentation.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [lib]
 proc-macro = true


### PR DESCRIPTION
Currently, the newly separated macro crate is missing some important cargo metadata (like the license).  Using a workspace allows the two crates to share the same information.