### PR TITLE
Add no_std compatibility

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+#![no_std]
+
+use core::ops::FnOnce;
+
 /// `TypedBuilder` is not a real type - deriving it will generate a `::builder()` method on your
 /// struct that will return a compile-time checked builder. Set the fields using setters with the
 /// same name as the struct's fields and call `.build()` when you are done to create your object.


### PR DESCRIPTION
Thanks for the effort in maintaining Typed Builder.

Our framework [LibAFL](https://github.com/AFLplusplus/LibAFL) is using Typed Builder in a no_std context and the recent update to 0.15.0 is breaking our library on bare metal targets.

In this PR, I introduce no_std compatibility. There is no downside, just an annotation and an import from core.

If you want to test it, use `cargo +nightly build -Zbuild-std=core --target aarch64-unknown-none` (you may want it in the CI script eventually).