### PR TITLE
Explicitly match unit type inside generated setters

### DIFF
--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -170,7 +170,7 @@ impl<'a> StructInfo<'a> {
 
         let descructuring = self.included_fields().map(|f| {
             if f.ordinal == field.ordinal {
-                quote!(_)
+                quote!(())
             } else {
                 let name = f.name;
                 name.to_token_stream()


### PR DESCRIPTION
This PR changes the usage of `_` to `()` inside setters.

When implementing a setter, the code will expand to something like this:

```rust
let (field, _) = self.fields;
```

While this is fine, with Rust 1.73 Clippy will introduce a new pedantic lint [`ignored_unit_patterns`](https://rust-lang.github.io/rust-clippy/master/index.html#/ignored_unit_patterns).  
This will result in warnings on each usage of the `TypedBuilder` macro.

With this one-line change, the expanded code will change to something like this:

```rust
let (field, ()) = self.fields;
```