### PR TITLE
Mutable assignments variables

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,6 +168,10 @@ use core::ops::FnOnce;
 ///   - `suffix = "..."` appends the setter method with the specified suffix. For example, setting
 ///     `suffix = "_value"` results in setters like `x_value` or `y_value`. This option is combinable
 ///     with `prefix = "..."`.
+///
+///   - `mutable_during_default_resolution`: when expressions in `default = ...` field attributes
+///     are evaluated, this field will be mutable, allowing earlier-defined fields to be mutated by
+///     later-defined fields.
 pub use typed_builder_macro::TypedBuilder;
 
 #[doc(hidden)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -812,7 +812,7 @@ fn test_mutable_defaults() {
             *x *= 2;
             *x
         } else {
-            Default::default() 
+            Default::default()
         })]
         y: i32,
     }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -800,3 +800,23 @@ fn test_issue_118() {
 
     let _ = Foo::<u32>::builder().build();
 }
+
+#[test]
+fn test_mutable_defaults() {
+    #[derive(TypedBuilder, PartialEq, Debug)]
+    struct Foo {
+        #[builder(default, mutable_during_default_resolution, setter(strip_option))]
+        x: Option<i32>,
+        #[builder(default = if let Some(x) = x.as_mut() {
+            *x *= 2;
+            *x
+        } else {
+            Default::default() 
+        })]
+        y: i32,
+    }
+
+    let foo = Foo::builder().x(5).build();
+
+    assert_eq!(foo, Foo { x: Some(10), y: 10 });
+}

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -116,6 +116,7 @@ pub struct FieldBuilderAttr<'a> {
     pub default: Option<syn::Expr>,
     pub deprecated: Option<&'a syn::Attribute>,
     pub setter: SetterSettings,
+    pub mutable_during_default_resolution: bool,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -200,6 +201,10 @@ impl<'a> FieldBuilderAttr<'a> {
                 match name.as_str() {
                     "default" => {
                         self.default = Some(syn::parse2(quote!(::core::default::Default::default())).unwrap());
+                        Ok(())
+                    }
+                    "mutable_during_default_resolution" => {
+                        self.mutable_during_default_resolution = true;
                         Ok(())
                     }
                     _ => Err(Error::new_spanned(&path, format!("Unknown parameter {:?}", name))),

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -115,7 +115,7 @@ pub struct FieldBuilderAttr<'a> {
     pub deprecated: Option<&'a syn::Attribute>,
     pub setter: SetterSettings,
     pub mutators: Vec<ItemFn>,
-    pub mutable_during_default_resolution: bool,
+    pub mutable_during_default_resolution: Option<Span>,
 }
 
 #[derive(Debug, Default, Clone)]
@@ -239,10 +239,10 @@ impl ApplyMeta for FieldBuilderAttr<'_> {
                 Ok(())
             }
             "setter" => self.setter.apply_sub_attr(expr),
-            "mutable_during_default_resolution" => {
-                self.mutable_during_default_resolution = true;
-                Ok(())
-            }
+            "mutable_during_default_resolution" => expr.apply_flag_to_field(
+                &mut self.mutable_during_default_resolution,
+                "made mutable during default resolution",
+            ),
             _ => Err(Error::new_spanned(
                 expr.name(),
                 format!("Unknown parameter {:?}", expr.name().to_string()),

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -500,7 +500,7 @@ impl<'a> StructInfo<'a> {
         };
 
         quote!(
-            #[allow(dead_code, non_camel_case_types, missing_docs)]
+            #[allow(dead_code, non_camel_case_types, missing_docs, unused_mut)]
             #[automatically_derived]
             impl #impl_generics #builder_name #modified_ty_generics #where_clause {
                 #build_method_doc

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -462,13 +462,22 @@ impl<'a> StructInfo<'a> {
             let name = &field.name;
             if let Some(ref default) = field.builder_attr.default {
                 if field.builder_attr.setter.skip.is_some() {
-                    quote!(let mut #name = #default;)
+                    quote! {
+                        #[allow(unused_mut)]
+                        let mut #name = #default;
+                    }
                 } else {
                     let crate_module_path = &self.builder_attr.crate_module_path;
-                    quote!(let mut #name = #crate_module_path::Optional::into_value(#name, || #default);)
+                    quote! {
+                        #[allow(unused_mut)]
+                        let mut #name = #crate_module_path::Optional::into_value(#name, || #default);
+                    }
                 }
             } else {
-                quote!(let mut #name = #name.0;)
+                quote! {
+                    #[allow(unused_mut)]
+                    let mut #name = #name.0;
+                }
             }
         });
         let field_names = self.fields.iter().map(|field| field.name);
@@ -500,7 +509,7 @@ impl<'a> StructInfo<'a> {
         };
 
         quote!(
-            #[allow(dead_code, non_camel_case_types, missing_docs, unused_mut)]
+            #[allow(dead_code, non_camel_case_types, missing_docs)]
             #[automatically_derived]
             impl #impl_generics #builder_name #modified_ty_generics #where_clause {
                 #build_method_doc

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -462,22 +462,33 @@ impl<'a> StructInfo<'a> {
             let name = &field.name;
             if let Some(ref default) = field.builder_attr.default {
                 if field.builder_attr.setter.skip.is_some() {
-                    quote! {
-                        #[allow(unused_mut)]
-                        let mut #name = #default;
+                    if field.builder_attr.mutable_during_default_resolution {
+                        quote! {
+                            #[allow(unused_mut)]
+                            let mut #name = #default;
+                        }
+                    } else {
+                        quote!(let #name = #default;)
                     }
                 } else {
                     let crate_module_path = &self.builder_attr.crate_module_path;
-                    quote! {
-                        #[allow(unused_mut)]
-                        let mut #name = #crate_module_path::Optional::into_value(#name, || #default);
+
+                    if field.builder_attr.mutable_during_default_resolution {
+                        quote! {
+                            #[allow(unused_mut)]
+                            let mut #name = #crate_module_path::Optional::into_value(#name, || #default);
+                        }
+                    } else {
+                        quote!(let #name = #crate_module_path::Optional::into_value(#name, || #default);)
                     }
                 }
-            } else {
+            } else if field.builder_attr.mutable_during_default_resolution {
                 quote! {
                     #[allow(unused_mut)]
                     let mut #name = #name.0;
                 }
+            } else {
+                quote!(let #name = #name.0;)
             }
         });
         let field_names = self.fields.iter().map(|field| field.name);

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -462,13 +462,13 @@ impl<'a> StructInfo<'a> {
             let name = &field.name;
             if let Some(ref default) = field.builder_attr.default {
                 if field.builder_attr.setter.skip.is_some() {
-                    quote!(let #name = #default;)
+                    quote!(let mut #name = #default;)
                 } else {
                     let crate_module_path = &self.builder_attr.crate_module_path;
-                    quote!(let #name = #crate_module_path::Optional::into_value(#name, || #default);)
+                    quote!(let mut #name = #crate_module_path::Optional::into_value(#name, || #default);)
                 }
             } else {
-                quote!(let #name = #name.0;)
+                quote!(let #name mut = #name.0;)
             }
         });
         let field_names = self.fields.iter().map(|field| field.name);

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -468,7 +468,7 @@ impl<'a> StructInfo<'a> {
                     quote!(let mut #name = #crate_module_path::Optional::into_value(#name, || #default);)
                 }
             } else {
-                quote!(let #name mut = #name.0;)
+                quote!(let mut #name = #name.0;)
             }
         });
         let field_names = self.fields.iter().map(|field| field.name);

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -460,35 +460,23 @@ impl<'a> StructInfo<'a> {
         // reordering based on that, but for now this much simpler thing is a reasonable approach.
         let assignments = self.fields.iter().map(|field| {
             let name = &field.name;
+
+            let maybe_mut = if field.builder_attr.mutable_during_default_resolution.is_some() {
+                quote!(mut)
+            } else {
+                quote!()
+            };
+
             if let Some(ref default) = field.builder_attr.default {
                 if field.builder_attr.setter.skip.is_some() {
-                    if field.builder_attr.mutable_during_default_resolution {
-                        quote! {
-                            #[allow(unused_mut)]
-                            let mut #name = #default;
-                        }
-                    } else {
-                        quote!(let #name = #default;)
-                    }
+                    quote!(let #maybe_mut #name = #default;)
                 } else {
                     let crate_module_path = &self.builder_attr.crate_module_path;
 
-                    if field.builder_attr.mutable_during_default_resolution {
-                        quote! {
-                            #[allow(unused_mut)]
-                            let mut #name = #crate_module_path::Optional::into_value(#name, || #default);
-                        }
-                    } else {
-                        quote!(let #name = #crate_module_path::Optional::into_value(#name, || #default);)
-                    }
-                }
-            } else if field.builder_attr.mutable_during_default_resolution {
-                quote! {
-                    #[allow(unused_mut)]
-                    let mut #name = #name.0;
+                    quote!(let #maybe_mut #name = #crate_module_path::Optional::into_value(#name, || #default);)
                 }
             } else {
-                quote!(let #name = #name.0;)
+                quote!(let #maybe_mut #name = #name.0;)
             }
         });
         let field_names = self.fields.iter().map(|field| field.name);


### PR DESCRIPTION
Very small change to allow a use case for LibAFL where a `default = ` expression needs to mutate another field. Here's a snippet for example:

```rust
/// Sending end on a (unidirectional) sharedmap channel
#[derive(TypedBuilder, Debug)]
#[builder(build_method(into = Result::<LlmpSender<SP>, Error>))]
pub struct LlmpSender<SP>
where
    SP: ShMemProvider,
{
    /// ID of this sender.
    id: ClientId,
    #[builder(default = ptr::null_mut())]
    /// Ref to the last message this sender sent on the last page.
    /// If null, a new page (just) started.
    last_msg_sent: *const LlmpMsg,
    #[builder(default)]
    /// A vec of pages that we previously used, but that have served its purpose
    /// (no potential readers are left).
    /// Instead of freeing them, we keep them around to potentially reuse them later,
    /// if they are still large enough.
    /// This way, the OS doesn't have to spend time zeroing pages, and getting rid of our old pages
    unused_shmem_cache: Vec<LlmpSharedMap<SP::ShMem>>,
    #[builder(default = false)]
    /// If true, pages will never be pruned.
    /// The broker uses this feature.
    /// By keeping the message history around,
    /// new clients may join at any time in the future.
    keep_pages_forever: bool,
    #[builder(default = false)]
    /// True, if we allocatd a message, but didn't call [`Self::send()`] yet
    has_unsent_message: bool,
    /// The sharedmem provider to get new sharaed maps if we're full
    shmem_provider: SP,
    #[builder(
        default = vec![LlmpSharedMap::new(id, shmem_provider.new_shmem(LLMP_CFG_INITIAL_MAP_SIZE).expect("Failed to create a new shared memory"))],
        setter(into))
    ]
    /// A vec of page wrappers, each containing an initialized [`ShMem`]
    out_shmems: Vec<LlmpSharedMap<SP::ShMem>>,
}
```