### PR TITLE
Add support for paths with angle brackets

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -720,6 +720,18 @@ fn test_into_set_generic_impl_from() {
 }
 
 #[test]
+fn test_into_angle_bracket_type() {
+    #[derive(Debug, PartialEq, TypedBuilder)]
+    #[builder(build_method(into = std::sync::Arc<Foo>))]
+    struct Foo {
+        value: i32,
+    }
+
+    let foo: std::sync::Arc<Foo> = Foo::builder().value(42).build();
+    assert_eq!(*foo, Foo { value: 42 });
+}
+
+#[test]
 fn test_into_set_generic_impl_into() {
     #[derive(TypedBuilder)]
     #[builder(build_method(into))]

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -222,7 +222,7 @@ impl ApplyMeta for FieldBuilderAttr<'_> {
                     Ok(())
                 }
                 AttrArg::KeyValue(key_value) => {
-                    self.default = Some(key_value.value);
+                    self.default = Some(key_value.value.unwrap_left());
                     Ok(())
                 }
                 AttrArg::Not { .. } => {
@@ -233,10 +233,10 @@ impl ApplyMeta for FieldBuilderAttr<'_> {
             },
             "default_code" => {
                 let value = expr.key_value()?.value;
-                if let syn::Expr::Lit(syn::ExprLit {
+                if let Either::Left(syn::Expr::Lit(syn::ExprLit {
                     lit: syn::Lit::Str(code),
                     ..
-                }) = value
+                })) = value
                 {
                     use std::str::FromStr;
                     let tokenized_code = TokenStream::from_str(&code.value())?;
@@ -293,12 +293,12 @@ impl ApplyMeta for SetterSettings {
     fn apply_meta(&mut self, expr: AttrArg) -> Result<(), Error> {
         match expr.name().to_string().as_str() {
             "doc" => {
-                self.doc = expr.key_value_or_not()?.map(|kv| kv.value);
+                self.doc = expr.key_value_or_not()?.map(|kv| kv.value.unwrap_left());
                 Ok(())
             }
             "transform" => {
                 self.transform = if let Some(key_value) = expr.key_value_or_not()? {
-                    Some(parse_transform_closure(key_value.name.span(), key_value.value)?)
+                    Some(parse_transform_closure(key_value.name.span(), key_value.value.unwrap_left())?)
                 } else {
                     None
                 };
@@ -306,7 +306,7 @@ impl ApplyMeta for SetterSettings {
             }
             "prefix" => {
                 self.prefix = if let Some(key_value) = expr.key_value_or_not()? {
-                    Some(expr_to_lit_string(&key_value.value)?)
+                    Some(expr_to_lit_string(&key_value.value.unwrap_left())?)
                 } else {
                     None
                 };
@@ -314,7 +314,7 @@ impl ApplyMeta for SetterSettings {
             }
             "suffix" => {
                 self.suffix = if let Some(key_value) = expr.key_value_or_not()? {
-                    Some(expr_to_lit_string(&key_value.value)?)
+                    Some(expr_to_lit_string(&key_value.value.unwrap_left())?)
                 } else {
                     None
                 };

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -706,7 +706,7 @@ impl ApplyMeta for BuildMethodSettings {
                 }
                 AttrArg::KeyValue(key_value) => {
                     let type_path = key_value.parse_value::<syn::TypePath>()?;
-                    self.into = IntoSetting::TypeConversionToSpecificType(type_path.clone());
+                    self.into = IntoSetting::TypeConversionToSpecificType(type_path);
                     Ok(())
                 }
                 _ => Err(expr.incorrect_type()),
@@ -784,7 +784,7 @@ impl ApplyMeta for TypeBuilderAttr<'_> {
         match expr.name().to_string().as_str() {
             "crate_module_path" => {
                 let crate_module_path = expr.key_value()?.parse_value::<syn::ExprPath>()?;
-                self.crate_module_path = crate_module_path.path.clone();
+                self.crate_module_path = crate_module_path.path;
                 Ok(())
             }
             "builder_method_doc" => Err(Error::new_spanned(

--- a/typed-builder-macro/src/util.rs
+++ b/typed-builder-macro/src/util.rs
@@ -338,7 +338,7 @@ impl ApplyMeta for MutatorAttribute {
             return Err(Error::new_spanned(expr.name(), "Only `requires` is supported"));
         }
 
-        match expr.key_value()?.value {
+        match expr.key_value()?.parse_value()? {
             Expr::Array(syn::ExprArray { elems, .. }) => self.requires.extend(
                 elems
                     .into_iter()


### PR DESCRIPTION
This PR adds support for paths of the `build_method(into)` field that contain angle brackets (such as `Arc<Foo>`)