### PR TITLE
Code cleanup. Make build method generate as const

### DIFF
--- a/typed-builder-macro/src/lib.rs
+++ b/typed-builder-macro/src/lib.rs
@@ -1,3 +1,5 @@
+#![forbid(rust_2018_idioms)]
+
 use proc_macro2::TokenStream;
 use quote::quote;
 use syn::{parse::Error, parse_macro_input, spanned::Spanned, DeriveInput};

--- a/typed-builder-macro/src/mutator.rs
+++ b/typed-builder-macro/src/mutator.rs
@@ -52,7 +52,7 @@ impl ApplyMeta for MutatorAttribute {
 }
 
 impl Parse for Mutator {
-    fn parse(input: ParseStream) -> syn::Result<Self> {
+    fn parse(input: ParseStream<'_>) -> syn::Result<Self> {
         let mut fun: ItemFn = input.parse()?;
 
         let mut attribute = MutatorAttribute::default();

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -1,4 +1,5 @@
 use std::cell::OnceCell;
+use std::rc::Rc;
 
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
@@ -86,7 +87,7 @@ impl<'a> StructInfo<'a> {
                 empty_type()
             }
         }));
-        let builder_method_const = std::rc::Rc::new(OnceCell::new());
+        let builder_method_const = Rc::new(OnceCell::new());
         let init_fields_expr = self
             .included_fields()
             .map({
@@ -105,7 +106,8 @@ impl<'a> StructInfo<'a> {
                 }
             })
             .collect::<Box<[_]>>();
-        let builder_method_const = builder_method_const.get_or_init(|| quote!(const));
+        let builder_method_const = Rc::into_inner(builder_method_const).unwrap();
+        let builder_method_const = OnceCell::into_inner(builder_method_const).unwrap_or_else(|| quote!(const));
         let mut all_fields_param_type: syn::TypeParam =
             syn::Ident::new("TypedBuilderFields", proc_macro2::Span::call_site()).into();
         let all_fields_param = syn::GenericParam::Type(all_fields_param_type.clone());

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -18,7 +18,7 @@ pub struct StructInfo<'a> {
     pub vis: &'a syn::Visibility,
     pub name: &'a syn::Ident,
     pub generics: &'a syn::Generics,
-    pub fields: Vec<FieldInfo<'a>>,
+    pub fields: Box<[FieldInfo<'a>]>,
 
     pub builder_attr: TypeBuilderAttr<'a>,
     pub builder_name: syn::Ident,


### PR DESCRIPTION
- Add `#![forbid(rust_2018_idioms)]` to the `typed-builder-macro` crate
- Make the builder function const when possible