### PR TITLE
Add support for `?Sized` generics

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -613,6 +613,20 @@ fn test_builder_on_struct_with_keywords_prefix_suffix() {
 }
 
 #[test]
+fn test_unsized_generic_params() {
+    use std::marker::PhantomData;
+
+    #[derive(TypedBuilder)]
+    struct GenericStructure<K, V>
+    where
+        K: ?Sized,
+    {
+        key: PhantomData<K>,
+        value: PhantomData<V>,
+    }
+}
+
+#[test]
 fn test_field_setter_transform() {
     #[derive(PartialEq)]
     struct Point {

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -188,9 +188,9 @@ impl<'a> StructInfo<'a> {
             #[must_use]
             #builder_type_doc
             #[allow(dead_code, non_camel_case_types, non_snake_case)]
-            #builder_type_visibility struct #builder_name #b_generics {
+            #builder_type_visibility struct #builder_name #b_generics #b_generics_where_extras_predicates {
                 fields: #all_fields_param,
-                phantom: ::core::marker::PhantomData<(#( #phantom_generics ),*)>,
+                phantom: (#( ::core::marker::PhantomData<#phantom_generics> ),*),
             }
 
             #[automatically_derived]
@@ -199,7 +199,7 @@ impl<'a> StructInfo<'a> {
                 fn clone(&self) -> Self {
                     Self {
                         fields: self.fields.clone(),
-                        phantom: ::core::marker::PhantomData,
+                        phantom: ::core::default::Default::default(),
                     }
                 }
             }

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -190,7 +190,7 @@ impl<'a> StructInfo<'a> {
             #[allow(dead_code, non_camel_case_types, non_snake_case)]
             #builder_type_visibility struct #builder_name #b_generics #b_generics_where_extras_predicates {
                 fields: #all_fields_param,
-                phantom: (#( ::core::marker::PhantomData<#phantom_generics> ),*),
+                phantom: ::core::marker::PhantomData<(#( ::core::marker::PhantomData<#phantom_generics> ),*)>,
             }
 
             #[automatically_derived]


### PR DESCRIPTION
This PR adds support for structs with `?Sized` generic parameters. Previously those were not accepted.

Technically this is a breaking change since this changes the internal `PhantomData` type from `PhantomData<(T1, T2)>` to `(PhantomData<T1>, PhantomData<T2>)`, and `Default` is only implemented for tuples of up to 12 items due to missing variadic generics.

Practically no struct should hit this limitation though.