### PR TITLE
Allow clippy::no_effect_underscore_binding

### DIFF
--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -299,7 +299,7 @@ impl<'a> StructInfo<'a> {
             impl #impl_generics #builder_name <#ty_generics> #where_clause {
                 #deprecated
                 #doc
-                #[allow(clippy::used_underscore_binding)]
+                #[allow(clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
                 pub fn #method_name (self, #param_list) -> #builder_name <#target_generics> {
                     let #field_name = (#arg_expr,);
                     let ( #(#descructuring,)* ) = self.fields;
@@ -462,7 +462,7 @@ impl<'a> StructInfo<'a> {
             #[automatically_derived]
             impl #impl_generics #builder_name <#ty_generics> #where_clause {
                 #(#attrs)*
-                #[allow(clippy::used_underscore_binding)]
+                #[allow(clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
                 #vis #sig {
                     struct #mutator_struct_name {
                         #mutator_ty_fields
@@ -617,7 +617,7 @@ impl<'a> StructInfo<'a> {
             #[automatically_derived]
             impl #impl_generics #builder_name #modified_ty_generics #where_clause {
                 #build_method_doc
-                #[allow(clippy::default_trait_access, clippy::used_underscore_binding)]
+                #[allow(clippy::default_trait_access, clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
                 #build_method_visibility fn #build_method_name #build_method_generic (self) -> #output_type #build_method_where_clause {
                     let ( #(#descructuring,)* ) = self.fields;
                     #( #assignments )*


### PR DESCRIPTION
```
error: binding to `_` prefixed variable with no side-effect
  --> fuc_engine/src/ops/remove.rs:32:10
   |
32 | #[derive(TypedBuilder, Debug)]
   |          ^^^^^^^^^^^^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#no_effect_underscore_binding
   = note: this error originates in the derive macro `TypedBuilder` (in Nightly builds, run with -Z macro-backtrace for more info)
```