### PR TITLE
Allow unused type in no_type_leakage test

### DIFF
--- a/tests/no_type_leakage.rs
+++ b/tests/no_type_leakage.rs
@@ -12,6 +12,7 @@ struct Foo {
     x: i32,
 }
 
+#[allow(unused)]
 pub struct Bar(Foo);
 
 impl Bar {


### PR DESCRIPTION
A contender for the world's smallest PR.

Right now, the code builds with a warning (for me):

```
warning: field `0` is never read
  --> tests/no_type_leakage.rs:15:16
   |
15 | pub struct Bar(Foo);
   |            --- ^^^
   |            |
   |            field in this struct
   |
   = note: `#[warn(dead_code)]` on by default
help: consider changing the field to be of unit type to suppress this warning while preserving the field numbering, or remove the field
   |
15 | pub struct Bar(());
   |             
```

This PR makes the type

```rust
#[allow(unused)]
pub struct Bar(Foo);
```

To suppress that warning.