### PR TITLE
Apply field doc-comments to builder methods

### DIFF
--- a/examples/example.rs
+++ b/examples/example.rs
@@ -2,12 +2,17 @@ use typed_builder::TypedBuilder;
 
 #[derive(Debug, PartialEq, TypedBuilder)]
 struct Foo {
-    // Mandatory Field:
+    /// `x` value.
+    ///
+    /// This field is mandatory.
     x: i32,
 
     // #[builder(default)] without parameter - use the type's default
     // #[builder(setter(strip_option))] - wrap the setter argument with `Some(...)`
-    #[builder(default, setter(strip_option))]
+    #[builder(
+        default,
+        setter(strip_option, doc = "Set `y`. If you don't specify a value it'll default to no value.",)
+    )]
     y: Option<i32>,
 
     // Or you can set the default

--- a/tests/no_std.rs
+++ b/tests/no_std.rs
@@ -52,10 +52,13 @@ fn test_into() {
 fn test_default() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo {
+        /// x value.
         #[builder(default, setter(strip_option))]
         x: Option<i32>,
         #[builder(default = 10)]
+        /// y value.
         y: i32,
+        /// z value.
         #[builder(default = [20, 30, 40])]
         z: [i32; 3],
     }

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -115,6 +115,7 @@ pub struct FieldBuilderAttr<'a> {
     pub default: Option<syn::Expr>,
     pub via_mutators: Option<ViaMutators>,
     pub deprecated: Option<&'a syn::Attribute>,
+    pub doc_comments: Vec<&'a syn::Expr>,
     pub setter: SetterSettings,
     /// Functions that are able to mutate fields in the builder that are already set
     pub mutators: Vec<Mutator>,
@@ -153,10 +154,20 @@ impl<'a> FieldBuilderAttr<'a> {
 
                     list
                 }
-                syn::Meta::Path(path) | syn::Meta::NameValue(syn::MetaNameValue { path, .. }) => {
-                    if path_to_single_string(path).as_deref() == Some("deprecated") {
-                        self.deprecated = Some(attr);
-                    };
+                syn::Meta::NameValue(syn::MetaNameValue { path, value, .. }) => {
+                    match path_to_single_string(path).as_deref() {
+                        Some("deprecated") => self.deprecated = Some(attr),
+                        Some("doc") => self.doc_comments.push(value),
+                        _ => continue,
+                    }
+
+                    continue;
+                }
+                syn::Meta::Path(path) => {
+                    match path_to_single_string(path).as_deref() {
+                        Some("deprecated") => self.deprecated = Some(attr),
+                        _ => continue,
+                    }
 
                     continue;
                 }


### PR DESCRIPTION
I noticed that the builder has support for explicitly provided comments, e.g. via

```rust
#[builder(
    default,
    setter(strip_option, doc = "Set `y`. If you don't specify a value it'll default to no value.",)
)]
```

However, regular doccomments would be ignored even when no setter-specific `doc` attribute is provided. With this PR, the following is now possible:

```rust
struct Foo {
    /// `x` value.
    ///
    /// This field is mandatory.
    x: i32,

    /// This doccomment is ignored for the setter. 
    #[builder(
        default,
        setter(strip_option, doc = "Set `y`. If you don't specify a value it'll default to no value.",)
    )]
    y: Option<i32>,

    #[builder(default = 20)]
    z: i32,
}
```

On the builder, `x(...)` will be documented with the regular doccomment, `y(...)` is documented with the setter attribute as before and `z(...)` remains undocumented, as before.

When the builder emits `deprecated` functions, they also inherit the documentation. This was not previously the case.
