### PR TITLE
Add a compile_fail test for mandatory fields

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,6 +256,19 @@ impl<T> Optional<T> for (T,) {
 // crate is all we can use.
 
 #[doc(hidden)]
+/// When a property is non-default, you can't ignore it:
+///
+/// ```compile_fail
+/// use typed_builder::TypedBuilder;
+///
+/// #[derive(TypedBuilder)]
+/// struct Foo {
+///     x: i8,
+/// }
+///
+/// let _ = Foo::builder().build();
+/// ```
+///
 /// When a property is skipped, you can't set it:
 /// (“method `y` not found for this”)
 ///


### PR DESCRIPTION
This adds an additional `compile_fail` test to ensure the following does not work:

```rust
use typed_builder::TypedBuilder;

#[derive(TypedBuilder)]
struct Foo {
    x: i8,
}

let _ = Foo::builder().build();
```

The functionality already worked as expected, it simply didn't seem to be covered by a test.