### PR TITLE
feat: add `strip_option(fallback = field_opt)`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Add `#[builder(setter(strip_option(fallback = "field_opt")))]` to add a fallback unstripped method to the builder struct.
+- Add `#[builder(setter(strip_option(fallback = field_opt)))]` to add a fallback unstripped method to the builder struct.
 
 ## 0.19.1 - 2024-07-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Add `#[builder(setter(strip_option(fallback = "field_opt")))]` to add a fallback unstripped method to the builder struct.
+
 ## 0.19.1 - 2024-07-14
 ### Fixed
 - Fix mutators for generic fields (see issue #149)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,6 +165,12 @@ use core::ops::FnOnce;
 ///     one cannot set the field to `None` with the setter - so the only way to get it to be `None`
 ///     is by using `#[builder(default)]` and not calling the field's setter.
 ///
+///   - `strip_option(fallback = "field_opt")`: for `Option<...>` fields only. As above this
+///      still wraps the argument with `Some(...)`. The name given to the fallback method adds
+///      another method to the builder without wrapping the argument in `Some`. This is useful
+///      when the codebase sometimes needs to pass in optional values. You can now call with
+///      `field_opt(Some(...))` instead of `field(...)`.
+///
 ///   - `strip_bool`: for `bool` fields only, this makes the setter receive no arguments and simply
 ///     set the field's value to `true`. When used, the `default` is automatically set to `false`.
 ///
@@ -359,5 +365,41 @@ impl<T> Optional<T> for (T,) {
 ///
 /// #[deny(deprecated)]
 /// Foo::builder().value(42).build();
-///```
+/// ```
+///
+/// Handling invalid property for `strip_option`
+///
+/// ```compile_fail
+/// use typed_builder::TypedBuilder;
+///
+/// #[derive(TypedBuilder)]
+/// struct Foo {
+///     #[builder(setter(strip_option(invalid_field = "should_fail")))]
+///     value: Option<i32>,
+/// }
+/// ```
+///
+/// Handling multiple properties for `strip_option`
+///
+/// ```compile_fail
+/// use typed_builder::TypedBuilder;
+///
+/// #[derive(TypedBuilder)]
+/// struct Foo {
+///     #[builder(setter(strip_option(fallback= "value_opt", fallback="value_opt2")))]
+///     value: Option<i32>,
+/// }
+/// ```
+///
+/// Handling empty properties for `strip_option`
+///
+/// ```compile_fail
+/// use typed_builder::TypedBuilder;
+///
+/// #[derive(TypedBuilder)]
+/// struct Foo {
+///     #[builder(setter(strip_option()))]
+///     value: Option<i32>,
+/// }
+/// ```
 fn _compile_fail_tests() {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl<T> Optional<T> for (T,) {
 ///
 /// Handling multiple properties for `strip_option`
 ///
-/// ```no_run
+/// ```compile_fail
 /// use typed_builder::TypedBuilder;
 ///
 /// #[derive(TypedBuilder)]
@@ -399,18 +399,6 @@ impl<T> Optional<T> for (T,) {
 /// #[derive(TypedBuilder)]
 /// struct Foo {
 ///     #[builder(setter(strip_option(type = value_opt, fallback = value_opt2)))]
-///     value: Option<i32>,
-/// }
-/// ```
-///
-/// Handling empty properties for `strip_option`
-///
-/// ```no_run
-/// use typed_builder::TypedBuilder;
-///
-/// #[derive(TypedBuilder)]
-/// struct Foo {
-///     #[builder(setter(strip_option()))]
 ///     value: Option<i32>,
 /// }
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,10 +165,9 @@ use core::ops::FnOnce;
 ///     one cannot set the field to `None` with the setter - so the only way to get it to be `None`
 ///     is by using `#[builder(default)]` and not calling the field's setter.
 ///
-///   - `strip_option(fallback = "field_opt")`: for `Option<...>` fields only. As above this
+///   - `strip_option(fallback = field_opt)`: for `Option<...>` fields only. As above this
 ///      still wraps the argument with `Some(...)`. The name given to the fallback method adds
-///      another method to the builder without wrapping the argument in `Some`. This is useful
-///      when the codebase sometimes needs to pass in optional values. You can now call with
+///      another method to the builder without wrapping the argument in `Some`. You can now call
 ///      `field_opt(Some(...))` instead of `field(...)`.
 ///
 ///   - `strip_bool`: for `bool` fields only, this makes the setter receive no arguments and simply

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,19 +381,31 @@ impl<T> Optional<T> for (T,) {
 ///
 /// Handling multiple properties for `strip_option`
 ///
+/// ```no_run
+/// use typed_builder::TypedBuilder;
+///
+/// #[derive(TypedBuilder)]
+/// struct Foo {
+///     #[builder(setter(strip_option(fallback = value_opt, fallback = value_opt2)))]
+///     value: Option<i32>,
+/// }
+/// ```
+///
+/// Handling alternative properties for `strip_option`
+///
 /// ```compile_fail
 /// use typed_builder::TypedBuilder;
 ///
 /// #[derive(TypedBuilder)]
 /// struct Foo {
-///     #[builder(setter(strip_option(fallback= "value_opt", fallback="value_opt2")))]
+///     #[builder(setter(strip_option(type = value_opt, fallback = value_opt2)))]
 ///     value: Option<i32>,
 /// }
 /// ```
 ///
 /// Handling empty properties for `strip_option`
 ///
-/// ```compile_fail
+/// ```no_run
 /// use typed_builder::TypedBuilder;
 ///
 /// #[derive(TypedBuilder)]

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -147,7 +147,7 @@ fn test_into_with_strip_option() {
 fn test_strip_option_with_fallback() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo {
-        #[builder(setter(strip_option(fallback = "x_opt")))]
+        #[builder(setter(strip_option(fallback = x_opt)))]
         x: Option<i32>,
     }
 
@@ -159,7 +159,7 @@ fn test_strip_option_with_fallback() {
 fn test_into_with_strip_option_with_fallback() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo {
-        #[builder(setter(into, strip_option(fallback = "x_opt")))]
+        #[builder(setter(into, strip_option(fallback = x_opt)))]
         x: Option<i32>,
     }
 

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -144,6 +144,30 @@ fn test_into_with_strip_option() {
 }
 
 #[test]
+fn test_strip_option_with_fallback() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        #[builder(setter(strip_option(fallback = "x_opt")))]
+        x: Option<i32>,
+    }
+
+    assert!(Foo::builder().x(1).build() == Foo { x: Some(1) });
+    assert!(Foo::builder().x_opt(Some(1)).build() == Foo { x: Some(1) });
+}
+
+#[test]
+fn test_into_with_strip_option_with_fallback() {
+    #[derive(PartialEq, TypedBuilder)]
+    struct Foo {
+        #[builder(setter(into, strip_option(fallback = "x_opt")))]
+        x: Option<i32>,
+    }
+
+    assert!(Foo::builder().x(1_u8).build() == Foo { x: Some(1) });
+    assert!(Foo::builder().x_opt(Some(1)).build() == Foo { x: Some(1) });
+}
+
+#[test]
 fn test_strip_bool() {
     #[derive(PartialEq, TypedBuilder)]
     struct Foo {

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -341,11 +341,12 @@ impl ApplyMeta for SetterSettings {
                 match expr {
                     AttrArg::Sub(sub) => {
                         let span = sub.span();
-                        let mut strip_option = Strip::new(span);
 
                         if self.strip_option.is_none() {
+                            let mut strip_option = Strip::new(span);
                             strip_option.apply_sub_attr(sub)?;
                             self.strip_option = Some(strip_option);
+
                             Ok(())
                         } else {
                             Err(Error::new(span, format!("Illegal setting - field is already {caption}")))
@@ -394,6 +395,13 @@ impl ApplyMeta for Strip {
     fn apply_meta(&mut self, expr: AttrArg) -> Result<(), Error> {
         match expr.name().to_string().as_str() {
             "fallback" => {
+                if self.fallback.is_some() {
+                    return Err(Error::new_spanned(
+                        expr.name(),
+                        format!("Duplicate fallback parameter {:?}", expr.name().to_string()),
+                    ));
+                }
+
                 let ident: syn::Ident = expr.key_value().map(|kv| kv.parse_value())??;
                 self.fallback = Some(ident);
                 Ok(())

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, quote, quote_spanned, ToTokens};
 use syn::{parse::Error, parse_quote, punctuated::Punctuated, GenericArgument, ItemFn, Token};
 
 use crate::builder_attr::{IntoSetting, TypeBuilderAttr};
-use crate::field_info::{FieldInfo, StripOption};
+use crate::field_info::FieldInfo;
 use crate::mutator::Mutator;
 use crate::util::{
     empty_type, empty_type_tuple, first_visibility, modify_types_generics_hack, phantom_data_for_generics, public_visibility,
@@ -284,12 +284,8 @@ impl<'a> StructInfo<'a> {
             let body = &transform.body;
             (quote!(#(#params),*), quote!({ #body }))
         } else if let Some(ref strip_option) = field.builder_attr.setter.strip_option {
-            if let StripOption::WithFallback(_, fallback_name) = strip_option {
-                strip_option_fallback = Some((
-                    syn::parse_str(fallback_name)?,
-                    quote!(#field_name: #field_type),
-                    quote!(#arg_expr),
-                ));
+            if let Some(ref fallback) = strip_option.fallback {
+                strip_option_fallback = Some((fallback.clone(), quote!(#field_name: #field_type), quote!(#arg_expr)));
             }
 
             (quote!(#field_name: #arg_type), quote!(Some(#arg_expr)))


### PR DESCRIPTION
### Description

Fixes #117 using the API described in https://github.com/idanarye/rust-typed-builder/issues/117#issuecomment-2178009713.

```rust
#[derive(TypedBuilder)]
struct SomeStruct {
     #[builder(default, setter(strip_option)]
     inner: Option<u32>,
     #[builder(setter(strip_option(fallback="outer_opt"))]
     outer: Option<u32>,

}

/// `strip_option` retains its current behaviour avoiding a breaking change.
/// `strip_option(fallback ="outer_opt")` strips the `Option`, and creates a fallback that still takes the option. 
/// This makes it fully opt-in.
fn new_api(value: Option<u32>) -> SomeStruct {
    match value {
        None => SomeStruct::builder().outer_opt(None).build(),
        Some(v) => SomeStruct::builder().inner(v).outer(v).build(),
    }
}

/// `strip_option(fallback ="outer_opt") makes the original `outer` builder method take the value, and creates an `outer_opt` which still takes an `Option`.
fn new_way(value: Option<u32>) -> SomeStruct {
    SomeStruct::builder().outer_opt(value).build()
}
```