### PR TITLE
Enhance TypedBuilder: Support Struct-Level Defaults for Fields

### DIFF
--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -991,3 +991,19 @@ fn test_mutators_for_generic_fields() {
 
     assert_eq!(Foo::builder().x_plus(1).y(2).build(), Foo { x: 1, y: 2 });
 }
+
+#[test]
+fn test_fields_global_defaults() {
+    #[derive(Debug, PartialEq, TypedBuilder)]
+    #[builder(field_global_defaults(default, setter(strip_option)))]
+    struct Foo {
+        x: Option<u32>,
+        y: Option<i32>,
+        z: Option<i32>,
+    }
+
+    let foo = Foo::builder().x(2).z(3).build();
+    assert_eq!(foo, Foo { x: Some(2), y: None, z: Some(3) });
+    let foo = Foo::builder().x(5).y(4).z(2).build();
+    assert_eq!(foo, Foo { x: Some(5), y: Some(4), z: Some(2) });
+}

--- a/typed-builder-macro/src/builder_attr.rs
+++ b/typed-builder-macro/src/builder_attr.rs
@@ -113,6 +113,8 @@ pub struct TypeBuilderAttr<'a> {
 
     pub field_defaults: FieldBuilderAttr<'a>,
 
+    pub field_global_defaults: FieldBuilderAttr<'a>,
+
     pub crate_module_path: syn::Path,
 
     /// Functions that are able to mutate fields in the builder that are already set
@@ -127,6 +129,7 @@ impl Default for TypeBuilderAttr<'_> {
             builder_type: Default::default(),
             build_method: Default::default(),
             field_defaults: Default::default(),
+            field_global_defaults: Default::default(),
             crate_module_path: syn::parse_quote!(::typed_builder),
             mutators: Default::default(),
         }
@@ -190,6 +193,7 @@ impl ApplyMeta for TypeBuilderAttr<'_> {
                 Ok(())
             }
             "field_defaults" => self.field_defaults.apply_sub_attr(expr.sub_attr()?),
+            "field_global_defaults" => self.field_global_defaults.apply_sub_attr(expr.sub_attr()?),
             "builder_method" => self.builder_method.apply_sub_attr(expr.sub_attr()?),
             "builder_type" => self.builder_type.apply_sub_attr(expr.sub_attr()?),
             "build_method" => self.build_method.apply_sub_attr(expr.sub_attr()?),

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -60,7 +60,7 @@ impl<'a> StructInfo<'a> {
             generics: &ast.generics,
             fields: fields
                 .enumerate()
-                .map(|(i, f)| FieldInfo::new(i, f, builder_attr.field_defaults.clone()))
+                .map(|(i, f)| FieldInfo::new(i, f, builder_attr.field_defaults.clone(), &builder_attr.field_global_defaults))
                 .collect::<Result<_, _>>()?,
             builder_attr,
             builder_name: syn::Ident::new(&builder_name, proc_macro2::Span::call_site()),


### PR DESCRIPTION
#### **Summary**  
This PR enhances the `TypedBuilder` derive macro by allowing users to define field defaults at the **struct level** instead of tagging each field individually. This simplifies usage and reduces boilerplate in structs with many optional fields.

#### **New Feature**  
- Introduced a **struct-level `#[builder(field_global_defaults(...))]` attribute**, which applies settings to all fields unless explicitly overridden.
- Fields now **inherit global defaults** unless they have specific attributes.

#### **Changes Implemented**  
1. **Extended `TypeBuilderAttr`**
   - Added `field_global_defaults` to store struct-level field settings.
   - Modified `ApplyMeta` to recognize `field_global_defaults` and parse settings.

2. **Updated `FieldInfo`**
   - Fields now merge their own attributes with global defaults.
   - Fields explicitly specifying attributes will **override global defaults**.

3. **Refactored `StructInfo`**
   - Passes struct-level defaults to `FieldInfo` when creating field definitions.

#### **Example Usage**
**Before (Without Struct-Level Defaults):**
```rust
#[derive(TypedBuilder)]
struct Foo {
    #[builder(default, setter(strip_option))]
    x: Option<i32>,   
    #[builder(default, setter(strip_option))]
    y: Option<i32>,
}
```

**After (With Struct-Level Defaults):**
```rust
#[derive(TypedBuilder)]
#[builder(field_global_defaults(default, setter(strip_option)))]
struct Foo {
    x: Option<i32>,  // Inherits `default` and `strip_option`
    y: Option<i32>,  // Inherits `default` and `strip_option`
}
```

#### **Why This Change?**
- **Reduces repetitive annotations** for structs with many optional fields.
- **Maintains backward compatibility**—existing field-specific annotations continue to work.

#### **Not included**
- allow only to overwrite Option<> related fields while non Option related fields stays untouched
- allow to overwrite the global setting on field level

