### PR TITLE
Improve `field_defaults(strip_option)` semantics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- Added `ignore_invalid` option to `strip_option` to skip stripping for non-Option fields
+- Added `fallback_prefix` and `fallback_suffix` options to `strip_option` for customizing fallback method names
+- Added support for field defaults with `strip_option` and its fallback options
+
+### Changed
+- Improved handling of `strip_option` to work better with field defaults
+- Made `strip_option` more flexible with non-Option fields when `ignore_invalid` is set
+
 ## 0.20.1 - 2025-03-14
 ### Fixed
 - Fix mutator with type parameter using associated type (see issue #157)
@@ -44,7 +53,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - `#[builder(mutators(...))]` to generate functions on builder to mutate fields
-- `#[builder(via_mutator)]` on fields to allow defining fields initialized 
+- `#[builder(via_mutator)]` on fields to allow defining fields initialized
   during `::builder()` for use with `mutators`
 - `mutable_during_default_resolution` to allow `default` expression mutate
   previous fields.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,29 +122,6 @@ use core::ops::FnOnce;
 ///    struct Point { x: f32, y: f32 }
 ///    ```
 ///
-///     The `setter(strip_option)` attribute now supports several new features:
-///
-///     - `ignore_invalid`: Skip stripping for non-Option fields instead of causing a compile error
-///     - `fallback_prefix`: Add a prefix to the fallback method name
-///     - `fallback_suffix`: Add a suffix to the fallback method name
-///
-///     Example:
-///
-///     ```
-///     use typed_builder::TypedBuilder;
-///
-///     #[derive(TypedBuilder)]
-///     #[builder(field_defaults(setter(strip_option(
-///         ignore_invalid,
-///         fallback_prefix = "opt_",
-///         fallback_suffix = "_val"
-///     ))))]
-///     struct Foo {
-///         x: Option<i32>,  // Can use .x(42) or .opt_x_val(None)
-///         y: i32,          // Uses .y(42) only since it's not an Option
-///     }
-///     ```
-///
 /// - `mutators(...)` takes functions, that can mutate fields inside of the builder.
 ///   See [mutators](#mutators) for details.
 ///
@@ -189,9 +166,32 @@ use core::ops::FnOnce;
 ///     is by using `#[builder(default)]` and not calling the field's setter.
 ///
 ///   - `strip_option(fallback = field_opt)`: for `Option<...>` fields only. As above this
-///      still wraps the argument with `Some(...)`. The name given to the fallback method adds
-///      another method to the builder without wrapping the argument in `Some`. You can now call
-///      `field_opt(Some(...))` instead of `field(...)`.
+///     still wraps the argument with `Some(...)`. The name given to the fallback method adds
+///     another method to the builder without wrapping the argument in `Some`. You can now call
+///     `field_opt(Some(...))` instead of `field(...)`.
+///
+///     The `setter(strip_option)` attribute supports several `field_defaults` features:
+///
+///     - `ignore_invalid`: Skip stripping for non-Option fields instead of causing a compile error
+///     - `fallback_prefix`: Add a prefix to every fallback method name
+///     - `fallback_suffix`: Add a suffix to every fallback method name
+///
+///     Example:
+///
+///     ```
+///     use typed_builder::TypedBuilder;
+///
+///     #[derive(TypedBuilder)]
+///     #[builder(field_defaults(setter(strip_option(
+///         ignore_invalid,
+///         fallback_prefix = "opt_",
+///         fallback_suffix = "_val"
+///     ))))]
+///     struct Foo {
+///         x: Option<i32>,  // Can use .x(42) or .opt_x_val(None)
+///         y: i32,          // Uses .y(42) only since it's not an Option
+///     }
+///     ```
 ///
 ///   - `strip_bool`: for `bool` fields only, this makes the setter receive no arguments and simply
 ///     set the field's value to `true`. When used, the `default` is automatically set to `false`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,6 +122,29 @@ use core::ops::FnOnce;
 ///    struct Point { x: f32, y: f32 }
 ///    ```
 ///
+///     The `setter(strip_option)` attribute now supports several new features:
+///
+///     - `ignore_invalid`: Skip stripping for non-Option fields instead of causing a compile error
+///     - `fallback_prefix`: Add a prefix to the fallback method name
+///     - `fallback_suffix`: Add a suffix to the fallback method name
+///
+///     Example:
+///
+///     ```
+///     use typed_builder::TypedBuilder;
+///
+///     #[derive(TypedBuilder)]
+///     #[builder(field_defaults(setter(strip_option(
+///         ignore_invalid,
+///         fallback_prefix = "opt_",
+///         fallback_suffix = "_val"
+///     ))))]
+///     struct Foo {
+///         x: Option<i32>,  // Can use .x(42) or .opt_x_val(None)
+///         y: i32,          // Uses .y(42) only since it's not an Option
+///     }
+///     ```
+///
 /// - `mutators(...)` takes functions, that can mutate fields inside of the builder.
 ///   See [mutators](#mutators) for details.
 ///

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -532,7 +532,6 @@ fn test_field_defaults_setter_options() {
     assert!(Foo::builder().x(1).y(2).build() == Foo { x: Some(1), y: 2 });
 }
 
-
 #[test]
 fn test_field_defaults_strip_option_ignore_invalid() {
     #[derive(TypedBuilder)]
@@ -544,10 +543,7 @@ fn test_field_defaults_strip_option_ignore_invalid() {
         z: Option<i32>,
     }
 
-    let foo = Foo::builder()
-        .x(42)
-        .y(10)
-        .build();
+    let foo = Foo::builder().x(42).y(10).build();
 
     assert_eq!(foo.x, Some(42));
     assert_eq!(foo.y, 10);
@@ -564,13 +560,9 @@ fn test_field_defaults_strip_option_fallback_suffix() {
         z: Option<i32>,
     }
 
-    let foo1 = Foo::builder()
-        .x(42)
-        .build();
+    let foo1 = Foo::builder().x(42).build();
 
-    let foo2 = Foo::builder()
-        .x_opt(None)
-        .build();
+    let foo2 = Foo::builder().x_opt(None).build();
 
     assert_eq!(foo1.x, Some(42));
     assert_eq!(foo1.z, Some(13));
@@ -588,13 +580,9 @@ fn test_field_defaults_strip_option_fallback_prefix() {
         z: Option<i32>,
     }
 
-    let foo1 = Foo::builder()
-        .x(42)
-        .build();
+    let foo1 = Foo::builder().x(42).build();
 
-    let foo2 = Foo::builder()
-        .opt_x(None)
-        .build();
+    let foo2 = Foo::builder().opt_x(None).build();
 
     assert_eq!(foo1.x, Some(42));
     assert_eq!(foo1.z, Some(13));
@@ -612,13 +600,9 @@ fn test_field_defaults_strip_option_fallback_prefix_and_suffix() {
         z: Option<i32>,
     }
 
-    let foo1 = Foo::builder()
-        .x(42)
-        .build();
+    let foo1 = Foo::builder().x(42).build();
 
-    let foo2 = Foo::builder()
-        .opt_x_val(None)
-        .build();
+    let foo2 = Foo::builder().opt_x_val(None).build();
 
     assert_eq!(foo1.x, Some(42));
     assert_eq!(foo1.z, Some(13));

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -532,6 +532,100 @@ fn test_field_defaults_setter_options() {
     assert!(Foo::builder().x(1).y(2).build() == Foo { x: Some(1), y: 2 });
 }
 
+
+#[test]
+fn test_field_defaults_strip_option_ignore_invalid() {
+    #[derive(TypedBuilder)]
+    #[builder(field_defaults(setter(strip_option(ignore_invalid))))]
+    struct Foo {
+        x: Option<i32>,
+        y: i32,
+        #[builder(default = Some(13))]
+        z: Option<i32>,
+    }
+
+    let foo = Foo::builder()
+        .x(42)
+        .y(10)
+        .build();
+
+    assert_eq!(foo.x, Some(42));
+    assert_eq!(foo.y, 10);
+    assert_eq!(foo.z, Some(13));
+}
+
+#[test]
+fn test_field_defaults_strip_option_fallback_suffix() {
+    #[derive(TypedBuilder)]
+    #[builder(field_defaults(setter(strip_option(fallback_suffix = "_opt"))))]
+    struct Foo {
+        x: Option<i32>,
+        #[builder(default = Some(13))]
+        z: Option<i32>,
+    }
+
+    let foo1 = Foo::builder()
+        .x(42)
+        .build();
+
+    let foo2 = Foo::builder()
+        .x_opt(None)
+        .build();
+
+    assert_eq!(foo1.x, Some(42));
+    assert_eq!(foo1.z, Some(13));
+    assert_eq!(foo2.x, None);
+    assert_eq!(foo2.z, Some(13));
+}
+
+#[test]
+fn test_field_defaults_strip_option_fallback_prefix() {
+    #[derive(TypedBuilder)]
+    #[builder(field_defaults(setter(strip_option(fallback_prefix = "opt_"))))]
+    struct Foo {
+        x: Option<i32>,
+        #[builder(default = Some(13))]
+        z: Option<i32>,
+    }
+
+    let foo1 = Foo::builder()
+        .x(42)
+        .build();
+
+    let foo2 = Foo::builder()
+        .opt_x(None)
+        .build();
+
+    assert_eq!(foo1.x, Some(42));
+    assert_eq!(foo1.z, Some(13));
+    assert_eq!(foo2.x, None);
+    assert_eq!(foo2.z, Some(13));
+}
+
+#[test]
+fn test_field_defaults_strip_option_fallback_prefix_and_suffix() {
+    #[derive(TypedBuilder)]
+    #[builder(field_defaults(setter(strip_option(fallback_prefix = "opt_", fallback_suffix = "_val"))))]
+    struct Foo {
+        x: Option<i32>,
+        #[builder(default = Some(13))]
+        z: Option<i32>,
+    }
+
+    let foo1 = Foo::builder()
+        .x(42)
+        .build();
+
+    let foo2 = Foo::builder()
+        .opt_x_val(None)
+        .build();
+
+    assert_eq!(foo1.x, Some(42));
+    assert_eq!(foo1.z, Some(13));
+    assert_eq!(foo2.x, None);
+    assert_eq!(foo2.z, Some(13));
+}
+
 #[test]
 fn test_clone_builder() {
     #[derive(PartialEq, Default)]

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -264,10 +264,19 @@ impl<'a> StructInfo<'a> {
         let arg_type = if field.builder_attr.setter.strip_option.is_some() && field.builder_attr.setter.transform.is_none() {
             if let Some(inner_type) = field.type_from_inside_option() {
                 inner_type
-            } else if field.builder_attr.setter.strip_option.as_ref().map_or(false, |s| s.ignore_invalid) {
+            } else if field
+                .builder_attr
+                .setter
+                .strip_option
+                .as_ref()
+                .map_or(false, |s| s.ignore_invalid)
+            {
                 field_type
             } else {
-                return Err(Error::new_spanned(field_type, "can't `strip_option` - field is not `Option<...>`"));
+                return Err(Error::new_spanned(
+                    field_type,
+                    "can't `strip_option` - field is not `Option<...>`",
+                ));
             }
         } else {
             field_type
@@ -286,27 +295,22 @@ impl<'a> StructInfo<'a> {
             .and_then(|strip_bool| strip_bool.fallback.as_ref())
             .map(|fallback| (fallback.clone(), quote!(#field_name: #field_type), quote!(#arg_expr)));
 
-        let strip_option_fallback = field
-            .builder_attr
-            .setter
-            .strip_option
-            .as_ref()
-            .and_then(|strip_option| {
-                if let Some(ref fallback) = strip_option.fallback {
-                    Some((fallback.clone(), quote!(#field_name: #field_type), quote!(#arg_expr)))
-                } else if let (Some(prefix), Some(suffix)) = (&strip_option.fallback_prefix, &strip_option.fallback_suffix) {
-                    let fallback_name = syn::Ident::new(&format!("{}{}{}", prefix, field_name, suffix), field_name.span());
-                    Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
-                } else if let Some(prefix) = &strip_option.fallback_prefix {
-                    let fallback_name = syn::Ident::new(&format!("{}{}", prefix, field_name), field_name.span());
-                    Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
-                } else if let Some(suffix) = &strip_option.fallback_suffix {
-                    let fallback_name = syn::Ident::new(&format!("{}{}", field_name, suffix), field_name.span());
-                    Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
-                } else {
-                    None
-                }
-            });
+        let strip_option_fallback = field.builder_attr.setter.strip_option.as_ref().and_then(|strip_option| {
+            if let Some(ref fallback) = strip_option.fallback {
+                Some((fallback.clone(), quote!(#field_name: #field_type), quote!(#arg_expr)))
+            } else if let (Some(prefix), Some(suffix)) = (&strip_option.fallback_prefix, &strip_option.fallback_suffix) {
+                let fallback_name = syn::Ident::new(&format!("{}{}{}", prefix, field_name, suffix), field_name.span());
+                Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
+            } else if let Some(prefix) = &strip_option.fallback_prefix {
+                let fallback_name = syn::Ident::new(&format!("{}{}", prefix, field_name), field_name.span());
+                Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
+            } else if let Some(suffix) = &strip_option.fallback_suffix {
+                let fallback_name = syn::Ident::new(&format!("{}{}", field_name, suffix), field_name.span());
+                Some((fallback_name, quote!(#field_name: #field_type), quote!(#arg_expr)))
+            } else {
+                None
+            }
+        });
 
         let (param_list, arg_expr) = if field.builder_attr.setter.strip_bool.is_some() {
             (quote!(), quote!(true))


### PR DESCRIPTION
### Description

Fixes #153

- Added `ignore_invalid`, `fallback_prefix`, and `fallback_suffix` options to `strip_option` for better customization.
- Improved handling of `strip_option` to support field defaults and non-Option fields when `ignore_invalid` is enabled.
- Added tests for new `strip_option` features to ensure functionality.