### PR TITLE
`#[builder(setter(transform_generics = "<...>"))]` to add generics to the `transform` closure.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## 0.21.3 - 2025-09-05
+## 0.21.3 - 2025-09-08
 
 ### Added
 - New optional alternate `transform` syntax using a full fn, to allow support for custom lifetimes, generics and a where clause to custom builder method.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+- `#[builder(setter(transform_generics = "<...>"))]` attribute for adding custom generics and lifetimes to the closure provided to `#[builder(setter(transform = ...))]`
+
 ## 0.21.2 - 2025-08-21
 ### Fixed
 - Recognize `TypeGroup` when checking for `Option`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,25 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `#[generics(<'a, A, B, ...>)]` can now be added as an attribute to the transform closure, e.g. `#[builder(setter(transform = #[generics(<A>)] |value: impl Foo<A>| expr))]`, to allow adding custom generics, bounds and lifetimes to the builder method.
+- New optional alternate `transform` syntax using a full fn, to allow support for custom lifetimes, generics and a where clause to custom builder method.
+
+Example:
+```rust
+#[derive(TypedBuilder)]
+struct Foo {
+    #[builder(
+        setter(
+            fn transform<'a, M>(value: impl IntoValue<'a, String, M>) -> String
+            where
+              M: std::fmt::Display
+            {
+                value.into_value()
+            },
+        )
+    )]
+    s: String,
+}
+```
 
 ## 0.21.2 - 2025-08-21
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## 0.21.3 - 2025-09-05
+
 ### Added
 - New optional alternate `transform` syntax using a full fn, to allow support for custom lifetimes, generics and a where clause to custom builder method.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- `#[builder(setter(transform_generics = "<...>"))]` attribute for adding custom generics and lifetimes to the closure provided to `#[builder(setter(transform = ...))]`
+- `#[generics(<'a, A, B, ...>)]` can now be added as an attribute to the transform closure, e.g. `#[builder(setter(transform = #[generics(<A>)] |value: impl Foo<A>| expr))]`, to allow adding custom generics, bounds and lifetimes to the builder method.
 
 ## 0.21.2 - 2025-08-21
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = [".", "./typed-builder-macro"]
 
 [workspace.package]
 description = "Compile-time type-checked builder derive"
-version = "0.21.2"
+version = "0.21.3"
 authors = ["IdanArye <idanarye@gmail.com>", "Chris Morgan <me@chrismorgan.info>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -27,4 +27,4 @@ keywords.workspace = true
 categories.workspace = true
 
 [dependencies]
-typed-builder-macro = { path = "typed-builder-macro", version = "=0.21.2" }
+typed-builder-macro = { path = "typed-builder-macro", version = "=0.21.3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,9 +203,21 @@ use core::ops::FnOnce;
 ///   - `transform = |param1: Type1, param2: Type2 ...| expr`: this makes the setter accept
 ///     `param1: Type1, param2: Type2 ...` instead of the field type itself. The parameters are
 ///     transformed into the field type using the expression `expr`. The transformation is performed
-///     when the setter is called.
-///     `#[generics(<'a, A, B, ...>)]` can be added as an attribute of the transform closure,
-///     to add these to the builder method. E.g. `transform = #[generics(<A>)] |value: impl Foo<A>| expr`
+///     when the setter is called. `transform` can also be provided in full `fn` syntax,
+///     to allow custom lifetimes, a generic and a where clause.
+///     Example:
+///     ```rust
+///     #[builder(
+///         setter(
+///             fn transform<'a, M>(value: impl IntoValue<'a, String, M>) -> String
+///             where
+///                 M: 'a,
+///             {
+///                 value.into_value()
+///             },
+///         )
+///     )]
+///     ```
 ///
 ///   - `prefix = "..."` prepends the setter method with the specified prefix. For example, setting
 ///     `prefix = "with_"` results in setters like `with_x` or `with_y`. This option is combinable

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -205,6 +205,11 @@ use core::ops::FnOnce;
 ///     transformed into the field type using the expression `expr`. The transformation is performed
 ///     when the setter is called.
 ///
+///   - `transform_generics = <'a, A, B, C, ...>`: used in conjunction with `transform`,
+///     these generics will be added to the builder method, and therefore available in the provided
+///     `transform` setter. Using prefix underscores, e.g. `'__a`/`__A` is recommended
+///     to avoid name clashes with others on the builder struct.
+///
 ///   - `prefix = "..."` prepends the setter method with the specified prefix. For example, setting
 ///     `prefix = "with_"` results in setters like `with_x` or `with_y`. This option is combinable
 ///     with `suffix = "..."`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -204,11 +204,8 @@ use core::ops::FnOnce;
 ///     `param1: Type1, param2: Type2 ...` instead of the field type itself. The parameters are
 ///     transformed into the field type using the expression `expr`. The transformation is performed
 ///     when the setter is called.
-///
-///   - `transform_generics = <'a, A, B, C, ...>`: used in conjunction with `transform`,
-///     these generics will be added to the builder method, and therefore available in the provided
-///     `transform` setter. Using prefix underscores, e.g. `'__a`/`__A` is recommended
-///     to avoid name clashes with others on the builder struct.
+///     `#[generics(<'a, A, B, ...>)]` can be added as an attribute of the transform closure,
+///     to add these to the builder method. E.g. `transform = #[generics(<A>)] |value: impl Foo<A>| expr`
 ///
 ///   - `prefix = "..."` prepends the setter method with the specified prefix. For example, setting
 ///     `prefix = "with_"` results in setters like `with_x` or `with_y`. This option is combinable

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -796,7 +796,7 @@ fn test_field_setter_transform_fn() {
     struct Foo {
         #[builder(
             setter(
-                fn transform<'a, M>(value: impl IntoValue<'a, String, M>) -> String
+                fn transform<'a, M>(value: impl IntoValue<'a, String, M>)
                 where
                     M: 'a,
                  {
@@ -807,7 +807,7 @@ fn test_field_setter_transform_fn() {
         s: String,
     }
 
-    // Check where clause
+    // Check where clause and return type
     #[derive(TypedBuilder)]
     struct Bar {
         #[builder(

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -796,8 +796,7 @@ fn test_field_setter_transform_with_generics() {
     struct Foo {
         #[builder(
             setter(
-                transform_generics = "<'__a, __Marker>",
-                transform = |value: impl IntoValue<'__a, String, __Marker>| value.into_value()
+                transform = #[generics(<'__a, __Marker>)] |value: impl IntoValue<'__a, String, __Marker>| value.into_value()
             )
         )]
         s: String,

--- a/typed-builder-macro/src/field_info.rs
+++ b/typed-builder-macro/src/field_info.rs
@@ -138,6 +138,7 @@ pub struct SetterSettings {
     pub strip_option: Option<Strip>,
     pub strip_bool: Option<Strip>,
     pub transform: Option<Transform>,
+    pub transform_generics: Option<syn::Generics>,
     pub prefix: Option<String>,
     pub suffix: Option<String>,
 }
@@ -320,6 +321,16 @@ impl ApplyMeta for SetterSettings {
             "transform" => {
                 self.transform = if let Some(key_value) = expr.key_value_or_not()? {
                     Some(parse_transform_closure(key_value.name.span(), key_value.parse_value()?)?)
+                } else {
+                    None
+                };
+                Ok(())
+            }
+            "transform_generics" => {
+                self.transform_generics = if let Some(key_value) = expr.key_value_or_not()? {
+                    let lit_str: syn::LitStr = syn::parse2(key_value.value)?;
+                    let generics: syn::Generics = lit_str.parse()?;
+                    Some(generics)
                 } else {
                     None
                 };

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -327,10 +327,6 @@ impl<'a> StructInfo<'a> {
                 .as_ref()
                 .map_or(quote!(), |g| g.to_token_stream());
 
-            // if field.builder_attr.setter.transform_generics.is_some() {
-            //     panic!("Generics: {:?}", method_generics);
-            // }
-
             (method_generics, quote!(#(#params),*), quote!({ #body }))
         } else if option_was_stripped {
             (quote!(), quote!(#field_name: #arg_type), quote!(Some(#arg_expr)))

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -320,12 +320,7 @@ impl<'a> StructInfo<'a> {
         } else if let Some(transform) = &field.builder_attr.setter.transform {
             let params = transform.params.iter().map(|(pat, ty)| quote!(#pat: #ty));
             let body = &transform.body;
-            let method_generics = field
-                .builder_attr
-                .setter
-                .transform_generics
-                .as_ref()
-                .map_or(quote!(), |g| g.to_token_stream());
+            let method_generics = transform.generics.as_ref().map_or(quote!(), |g| g.to_token_stream());
 
             (method_generics, quote!(#(#params),*), quote!({ #body }))
         } else if option_was_stripped {

--- a/typed-builder-macro/src/struct_info.rs
+++ b/typed-builder-macro/src/struct_info.rs
@@ -315,16 +315,27 @@ impl<'a> StructInfo<'a> {
             }
         });
 
-        let (param_list, arg_expr) = if field.builder_attr.setter.strip_bool.is_some() {
-            (quote!(), quote!(true))
+        let (method_generics, param_list, arg_expr) = if field.builder_attr.setter.strip_bool.is_some() {
+            (quote!(), quote!(), quote!(true))
         } else if let Some(transform) = &field.builder_attr.setter.transform {
             let params = transform.params.iter().map(|(pat, ty)| quote!(#pat: #ty));
             let body = &transform.body;
-            (quote!(#(#params),*), quote!({ #body }))
+            let method_generics = field
+                .builder_attr
+                .setter
+                .transform_generics
+                .as_ref()
+                .map_or(quote!(), |g| g.to_token_stream());
+
+            // if field.builder_attr.setter.transform_generics.is_some() {
+            //     panic!("Generics: {:?}", method_generics);
+            // }
+
+            (method_generics, quote!(#(#params),*), quote!({ #body }))
         } else if option_was_stripped {
-            (quote!(#field_name: #arg_type), quote!(Some(#arg_expr)))
+            (quote!(), quote!(#field_name: #arg_type), quote!(Some(#arg_expr)))
         } else {
-            (quote!(#field_name: #arg_type), arg_expr)
+            (quote!(), quote!(#field_name: #arg_type), arg_expr)
         };
 
         let repeated_fields_error_type_name = syn::Ident::new(
@@ -344,7 +355,7 @@ impl<'a> StructInfo<'a> {
                 #deprecated
                 #doc
                 #[allow(clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
-                pub fn #method_name (self, #param_list) -> #builder_name <#target_generics> {
+                pub fn #method_name #method_generics (self, #param_list) -> #builder_name <#target_generics> {
                     let #field_name = (#arg_expr,);
                     let ( #(#destructuring,)* ) = self.fields;
                     #builder_name {
@@ -362,7 +373,7 @@ impl<'a> StructInfo<'a> {
                 #deprecated
                 #doc
                 #[allow(clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
-                pub fn #method_name (self, #param_list) -> #builder_name <#target_generics> {
+                pub fn #method_name #method_generics (self, #param_list) -> #builder_name <#target_generics> {
                     let #field_name = (#arg_expr,);
                     let ( #(#destructuring,)* ) = self.fields;
                     #builder_name {
@@ -382,7 +393,7 @@ impl<'a> StructInfo<'a> {
                 #deprecated
                 #doc
                 #[allow(clippy::used_underscore_binding, clippy::no_effect_underscore_binding)]
-                pub fn #method_name (self, #param_list) -> #builder_name <#target_generics> {
+                pub fn #method_name #method_generics (self, #param_list) -> #builder_name <#target_generics> {
                     let #field_name = (#arg_expr,);
                     let ( #(#destructuring,)* ) = self.fields;
                     #builder_name {
@@ -405,7 +416,7 @@ impl<'a> StructInfo<'a> {
                     note = #repeated_fields_error_message
                 )]
                 #doc
-                pub fn #method_name (self, _: #repeated_fields_error_type_name) -> #builder_name <#target_generics> {
+                pub fn #method_name #method_generics (self, _: #repeated_fields_error_type_name) -> #builder_name <#target_generics> {
                     self
                 }
             }


### PR DESCRIPTION
Love the library! 

This PR adds a `transform_generics` config to allow adding generic parameters and lifetimes to the closure provided by `#[builder(setter(transform = "..."))]`

The goal is to be able to replicate this setter:
```rust
pub fn set_s<M>(s: impl IntoValue<String, M>) -> String {
    s.into_value()
}
```

And with this PR can be done as:

```rust
#[derive(TypedBuilder)]
struct Foo {
    #[builder(
        setter(
            transform_generics = "<__Marker>",
            transform = |value: impl IntoValue<String, __Marker>| value.into_value()
        )
    )]
    s: String,
}
```

I don't have any preference for this specific syntax, this just seemed to be the simplest non-breaking way to add the functionality, happy to change the implementation if it still adds the same new functionality?

An example of a usecase for this ([real usecase in leptos](https://github.com/leptos-rs/leptos/pull/4273)):
```rust
struct MBaseCase;

struct MClosure;

trait IntoValue<T, M> {
    fn into_value(self) -> T;
}

impl<T, I> IntoValue<T, MBaseCase> for I
where
    I: Into<T>,
{
    fn into_value(self) -> T {
        self.into()
    }
}

impl<T, F> IntoValue<T, MClosure> for F
where
    F: FnOnce() -> T,
{
    fn into_value(self) -> T {
        self()
    }
}
```

With this custom transform setter, I can now use either `T` or `|| T`